### PR TITLE
feat: rename text difficulty CLI to lexile-scoring-model-pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,140 +1,147 @@
 # Lexile Corpus Tuner
 
-Lexile Corpus Tuner helps keep text at a ~350 Lexile level (10-year-old readers) by analyzing overlapping windows and rewriting the hard parts. The project ships two coordinated toolsets that share tokenization/normalization utilities so corpus statistics and analyzer features stay aligned.
+Lexile Corpus Tuner is a toolkit for measuring, constraining, and rewriting a corpus based on the text difficulty level. It was designed to expand the availability of high / low reading material for struggling readers. It pairs a Lexile-style rewriting pipeline with a Lexile-approximation scoring model to produce texts that are calibrated to a reader's skill level. Since Lexile is a proprietary and closed system, a scoring model was developed to approximate lexile scores. This includes a corpus/analyzer/calibration stack that curates a custom mega-corpus, analyzes word frequency and sentence length, and then calibrates an overal score against known lexile measurements. 
 
-1. **Lexile Tuner CLI (`lexile-tuner`)** - analyze + optionally rewrite text with pluggable estimators and an OpenAI-backed rewriter.
-2. **Lexile-Faithful Text Difficulty Pipeline (`text-difficulty-pipeline`)** - build a proxy corpus (Gutenberg, Simple Wiki, OpenStax/CK-12), compute 5M-token frequency tables, extract Lexile-style features, and fit a regression-calibrated analyzer.
-3. **Gutenberg Query Builder (CLI + GUI)** - explore and export Gutenberg metadata with structured queries.
+## What You Can Do
 
-For the step-by-step build specification, see [`docs/text-difficulty-pipeline.md`](docs/text-difficulty-pipeline.md).
+- Identify portions of a text that exceed a configurable maximium difficulty level.
+- Determine key words and sentences that trigger the violation
+- Rewrite portions of this text to avoid exceeding configured maximums
+- Build a custom Lexile-approximation model:
 
----
+  - Semi-automated curation of sources used for the mega-corpus
+  - Download and consolidate the mega-corpus
+  - Analyze the mega-corpus and individual texts to extract meta-metrics
+  - Calibrate these metrics by fitting a model based on word frequency and sentence length to known lexile levels
 
-## Quick Install
+## Install
 
 ```bash
 poetry install --with dev
 # Optional extras
-# poetry install --with dev --extras "lexile-v2"
-# poetry install --with dev --extras "llm-openai"
+poetry install --with dev --extras "lexile-v2"   # TensorFlow Lexile v2 adapter
+poetry install --with dev --extras "llm-openai"  # OpenAI-backed rewriting
 ```
-
-Formatting uses `black` (88 chars) + `isort` (per-project config).
-
----
 
 ## CLI Quickstarts
 
-### Lexile Tuner CLI
+### Lexile Tuner (`lexile-tuner`)
 
 ```bash
+# Analyze and report Lexile-style violations (no rewrites)
 poetry run lexile-tuner analyze --input-path examples/example_corpus --config examples/example_config.yaml
-poetry run lexile-tuner rewrite --input-path examples/example_corpus --output-path artifacts/tuned --config examples/example_config.yaml
+
+# Rewrite violating windows and emit tuned copies + summary.json
+poetry run lexile-tuner rewrite \
+  --input-path examples/example_corpus \
+  --output-path artifacts/tuned \
+  --config examples/example_config.yaml
+
+# Inspect defaults
 poetry run lexile-tuner print-config
 poetry run lexile-tuner analyze --input-path examples/example_corpus/pg2701-images-3.epub
 ```
 
-### Text Difficulty Pipeline
+### Lexile Scoring Model Pipeline (`lexile-scoring-model-pipeline`, alias: `text-difficulty-pipeline`)
 
 ```bash
-# Optional: regenerate Gutenberg IDs (strict English)
+# Optional helpers
 poetry run python -m lexile_corpus_tuner.lexile_scoring_model.pipeline_scripts.build_gutenberg_id_list
-
-# Optional: copy examples/meta/oer_sources.example.json to data/meta/oer_sources.json and fill in OpenStax/CK-12 excerpts
+# Copy examples/meta/oer_sources.example.json to data/meta/oer_sources.json if using OER excerpts
 
 # 1) Download raw sources (Gutenberg + Simple Wiki + OER manifest)
-poetry run text-difficulty-pipeline corpus download
+poetry run lexile-scoring-model-pipeline corpus download
 
 # 2) Convert Simple Wiki dump to JSONL articles
 poetry run python -m lexile_corpus_tuner.lexile_scoring_model.pipeline_scripts.extract_simple_wiki_dump \
   --dump data/corpus/raw/simple_wiki/simplewiki-latest-pages-articles.xml.bz2 \
   --output data/corpus/raw/simple_wiki/simplewiki_articles.jsonl
 
-# 3) Normalize & shard
-poetry run text-difficulty-pipeline corpus normalize --shard-size-tokens 100000
+# 3) Normalize & shard (shared tokenizer/normalizer)
+poetry run lexile-scoring-model-pipeline corpus normalize --shard-size-tokens 100000
 
 # 4) Compute frequency table (per-source weights honored)
-poetry run text-difficulty-pipeline corpus frequencies
+poetry run lexile-scoring-model-pipeline corpus frequencies
 
-# 5) Calibration workflow (requires data/calibration/catalog/lexile_catalog.csv)
-poetry run text-difficulty-pipeline calibration fetch-texts \
+# 5) Calibration workflow (needs data/calibration/catalog/lexile_catalog.csv and downloaded texts)
+poetry run lexile-scoring-model-pipeline calibration fetch-texts \
   --catalog data/calibration/catalog/lexile_catalog.csv \
   --texts-root data/calibration/texts
 
-poetry run text-difficulty-pipeline calibration build-dataset \
+poetry run lexile-scoring-model-pipeline calibration build-dataset \
   --catalog data/calibration/catalog/lexile_catalog.csv \
   --texts-root data/calibration/texts \
   --output data/calibration/calibration_dataset.parquet
 
-poetry run text-difficulty-pipeline calibration fit \
+poetry run lexile-scoring-model-pipeline calibration fit \
   data/calibration/calibration_dataset.parquet \
   --out data/model/lexile_regression_model.json
 
-# 6) Analyze new text with the Lexile-faithful analyzer
-poetry run text-difficulty-pipeline analyze text path/to/doc.txt --json-output report.json
+# 6) Analyze new text with the calibrated analyzer
+poetry run lexile-scoring-model-pipeline analyze text path/to/doc.txt --json-output report.json
 ```
 
 ### Gutenberg Corpus Explorer
 
 ```bash
-# CLI
+# CLI (Boolean query engine over metadata parquet)
 poetry run python -m lexile_corpus_tuner.lexile_scoring_model.pipeline_scripts.explore_gutenberg
 
-# GUI
+# GUI (Tkinter query builder with save/load/export)
 poetry run python -m lexile_corpus_tuner.lexile_scoring_model.pipeline_scripts.gutenberg_query_builder_ui
 ```
 
-Features: structured queries (field/value, ranges, boolean), sortable results table (first 100 rows), save/load/export to CSV or Parquet, keyboard shortcuts, and drag-and-drop nested groups.
+Requires `data/meta/gutenberg_metadata.parquet` to be present.
 
----
+## Flow Maps
 
-## Architecture and Domain Model
+**Build the calibrated Lexile-style model**
+```
+lexile-scoring-model-pipeline corpus download
+  -> corpus normalize --shard-size-tokens 100000
+  -> corpus frequencies
+  -> calibration fetch-texts --catalog data/calibration/catalog/lexile_catalog.csv --texts-root data/calibration/texts
+  -> calibration build-dataset --catalog data/calibration/catalog/lexile_catalog.csv --texts-root data/calibration/texts --output data/calibration/calibration_dataset.parquet
+  -> calibration fit data/calibration/calibration_dataset.parquet --out data/model/lexile_regression_model.json
+```
 
-**Core pipeline:** `Document -> Tokenization -> Windowing -> Scoring -> Constraint Checking -> (Rewriting?) -> Output`.
+**Run the rewriting pipeline**
+```
+lexile-tuner analyze --input-path <txt|epub|dir> [--config ...]           # inspect violations only
+lexile-tuner rewrite --input-path <...> --output-path <out> [--config ...] \
+  [--estimator-name lexile_v2|dummy] [--openai-* flags when using llm-openai extra]
+  -> Baseline stats (no rewrite)
+  -> Optional OpenAI-backed rewrites of violating windows
+  -> Tuned documents + summary.json under output-path
+```
 
-**Module map (lexile_tuner):** `models.py` (Document/Token/Window/WindowScore/ConstraintViolation), `tokenization.py`, `windowing.py`, `estimators/` (dummy + optional `lexile_determination_v2_adapter.py`), `scoring.py`, `constraints.py`, `rewriting.py`, `pipeline.py`, `cli.py`, `config.py`.
+## Data & Artifacts
 
-**Domain entities:**
+- Corpus artifacts: `data/corpus/raw`, `data/corpus/normalized/shards`
+- Frequency tables: `data/freq/word_frequencies.tsv` (+ `.meta.json`)
+- Calibration assets: `data/calibration/catalog/*.csv`, `data/calibration/texts`, `data/calibration/calibration_dataset.parquet`
+- Model output: `data/model/lexile_regression_model.json`
+  All of the above are git-ignored; commands are deterministic given the same inputs.
 
-- `Document` with ID + raw text
-- `Token` with character offsets
-- `Window` (overlapping token spans)
-- `WindowScore` (window + Lexile score)
-- `DocumentLexileStats` (aggregate statistics)
-- `ConstraintViolation` (per-window/document issues)
+## Package Layout (src/lexile_corpus_tuner)
 
-**Design principles:** pluggable estimators/rewriters, isolation of external deps, deterministic/testable core, YAML-configurable CLI overrides.
+- `cli.py`: entry points `lexile-tuner` and `lexile-scoring-model-pipeline` (alias: `text-difficulty-pipeline`)
+- `corpus_tuning_pipeline/`: tokenization, windowing, constraints, scoring, rewriting, EPUB ingestion, text difficulty pipeline runner
+- `lexile_scoring_model/`: `corpus` (download/normalize/frequencies), `analyzer` (slices/features/CLI), `calibration` (dataset build + fit/CLI), `pipeline_scripts` (Gutenberg helpers, query builder, Simple Wiki extractor)
+- `estimators/`: dummy estimator and optional TensorFlow Lexile v2 adapter
+- `llm/`: OpenAI rewrite client used by `lexile-tuner` when `llm-openai` extra is installed
+- `config.py`, `models.py`, `frequency_loader.py`: shared config, domain models, and frequency loading helpers
 
----
+## Development & CI
 
-## Configuration
-
-`LexileTunerConfig` defaults: `window_size=500`, `stride=250`, `max_window_lexile=450.0`, `target_avg_lexile=350.0`, `avg_tolerance=20.0`, `max_passes=3`, `estimator_name="dummy"`, `rewrite_enabled=False`, `rewrite_model` optional. Load via `config_from_dict` or `config_from_yaml`, or pass overrides on the CLI.
-
----
-
-## Extension Points
-
-- **Estimators:** implement `LexileEstimator.predict_scalar(text: str) -> float` and register via `create_estimator(name, **kwargs)`.
-- **Rewriters:** implement `Rewriter.rewrite(request: RewriteRequest) -> str`. Built-ins: `NoOpRewriter`, `CallableRewriter`, `OpenAIRewriter`.
-
----
-
-## External Integrations and Secrets
-
-- **Lexile V2 (optional):** TensorFlow adapter for backwards compatibility (`estimator_name: lexile_v2`, artifacts under `examples/lexile_v2_artifacts/`).
-- **OpenAI rewriting (optional):** install `llm-openai`, set `rewrite_enabled: true`, and pass `--openai-*` flags as needed.
-- **Secret handling:** never commit keys. Load OpenAI keys from LastPass: `pwsh ./src/lexile_corpus_tuner/lexile_scoring_model/pipeline_scripts/load-openai-key.ps1 -ItemName "Lexile OpenAI Key"`. Config supports direct values or env-var indirection.
-
----
-
-## Developer Workflow and Quality
-
-- Policies: follow [`docs/code-change.instructions.md`](docs/code-change.instructions.md) for coding standards and workflow, [`docs/developer-tooling.md`](docs/developer-tooling.md) for tooling, and [`docs/unit-test-policy.md`](docs/unit-test-policy.md) for tests.
-- Common tasks: `poetry run black .`, `poetry run ruff check`, `poetry run pyright`, `poetry run pytest` (or VS Code tasks: Run All Checks).
-- CI mirrors these checks across Python 3.10-3.13; see [`docs/ci-documentation.md`](docs/ci-documentation.md).
-
----
+- Tooling: Black (88), Ruff, Pyright (strict), Pytest. See `docs/developer-tooling.md`.
+- CI: matrix for Python 3.10–3.13 plus security/build/docs checks (`docs/ci-documentation.md`).
+- Policies: `.github/instructions/general-code-change.instructions.md`, `.github/instructions/python-code-change.instructions.md`, `.github/instructions/general-unit-test.instructions.md`, `.github/instructions/python-unit-test.instructions.md`.
+- Common commands:
+  - `poetry run black .`
+  - `poetry run ruff check`
+  - `poetry run pyright`
+  - `poetry run pytest`
 
 ## Examples
 
@@ -144,46 +151,12 @@ Features: structured queries (field/value, ranges, boolean), sortable results ta
 - `examples/run_openai_rewrite.py`
 - `examples/meta/oer_sources.example.json`
 
----
+## Docs & Roadmap
 
-## Testing
-
-```bash
-poetry run pytest
-poetry run pyright
-poetry run black --check .
-poetry run isort --check-only .
-```
-
----
-
-## Documentation Map
-
-- Implementation plan: [`docs/text-difficulty-pipeline.md`](docs/text-difficulty-pipeline.md)
-- Coding standards: [`docs/code-change.instructions.md`](docs/code-change.instructions.md)
-- Developer tooling: [`docs/developer-tooling.md`](docs/developer-tooling.md)
-- Unit tests: [`docs/unit-test-policy.md`](docs/unit-test-policy.md)
-- CI setup: [`docs/ci-documentation.md`](docs/ci-documentation.md)
-- Feature backlog/ideas: [`docs/features/backlog.md`](docs/features/backlog.md), [`docs/features/ideas/ideas.md`](docs/features/ideas/ideas.md)
-
----
-
-## Next Steps / Roadmap
-
-1. Promote pipeline docs into README/docs.
-2. Expand corpus with CC-BY/CC0 informational sources and weighting.
-3. Advanced weighting/stratified sharding to keep Gutenberg under target share.
-4. Rich calibration diagnostics (per-band metrics, residual plots, reporting).
-5. Package/release to PyPI when docs/tests stabilize.
-6. Evaluator benchmarks against known Lexile values.
-7. Deprecate `lexile_v2` after calibrated analyzer fully replaces it.
+- Lexile-faithful initiative: `docs/features/active/lexile-faithful-text-difficulty-pipeline/initiative.md`
+- Refactor structure spec: `docs/features/active/lexile-refactor-pipeline-structure/spec.md`
+- Active feature specs/plans: `docs/features/active/`
+- Backlog: `docs/features/backlog.md`
+- Testing guidance: `docs/unit-test-policy.md`
 
 Contributions and issue reports are welcome!
-
-
-
-
-
-
-
-

--- a/docs/ci-documentation.md
+++ b/docs/ci-documentation.md
@@ -44,7 +44,7 @@ Runs on: Python 3.13
 **Steps:**
 - Builds the package using Poetry
 - Installs the built wheel in a clean venv
-- Verifies both CLI entry points work (`lexile-tuner`, `text-difficulty-pipeline`)
+- Verifies both CLI entry points work (`lexile-tuner`, `lexile-scoring-model-pipeline`; alias `text-difficulty-pipeline`)
 
 ## Local Development
 

--- a/docs/features/active/lexile-faithful-text-difficulty-pipeline/initiative.md
+++ b/docs/features/active/lexile-faithful-text-difficulty-pipeline/initiative.md
@@ -31,7 +31,7 @@ Dependencies: Analyzer requires corpus frequencies; Calibration requires analyze
 - M1 Corpus frequencies available (download → normalize → frequencies) — ✔ Implemented
 - M2 Analyzer features available (slices, MSL/MLF, adjustments) — ✔ Implemented
 - M3 Calibrated model exported (dataset build, fit, JSON spec) — ✔ Implemented
-- CLI alignment: `lexile-corpus-tuner` exposes `corpus`, `analyze`, and `calibration` subcommands; end-to-end pipeline reachable via `text-difficulty-pipeline` workflow.
+- CLI alignment: `lexile-corpus-tuner` exposes `corpus`, `analyze`, and `calibration` subcommands; end-to-end pipeline reachable via `lexile-scoring-model-pipeline` workflow (alias: `text-difficulty-pipeline`).
 
 ## Initiative-Level Validation
 

--- a/docs/features/active/lexile-refactor-pipeline-structure/spec.md
+++ b/docs/features/active/lexile-refactor-pipeline-structure/spec.md
@@ -11,7 +11,7 @@ Retire the ad-hoc `scripts/production` layout and house the Lexile-faithful pipe
 
 ## Invariants (must not change)
 
-- CLI surfaces and flags for corpus/analyzer/calibration/text-difficulty-pipeline flows remain identical.
+- CLI surfaces and flags for corpus/analyzer/calibration/lexile-scoring-model-pipeline flows remain identical (legacy alias: text-difficulty-pipeline).
 - Input/output file shapes and default data locations (e.g., `data/corpus/*`, `data/freq/word_frequencies.tsv`, `data/calibration/*`, `data/model/lexile_regression_model.json`) remain the same.
 - Pipeline determinism and processing logic stay unchanged; only module paths and imports move.
 - Existing VS Code launch/task behaviors are preserved (commands still runnable, even if the underlying path moves).
@@ -20,7 +20,7 @@ Retire the ad-hoc `scripts/production` layout and house the Lexile-faithful pipe
 ## Scope (structural changes)
 
 - Move `scripts/production/*` into `src/lexile_corpus_tuner/pipeline_scripts/` with `__init__.py` as needed; update imports to package-style absolute imports.
-- Align module names/entry points to the existing CLI (`lexile_corpus_tuner.cli` text-difficulty group) and any UI modules (e.g., Gutenberg query builder) under the package.
+- Align module names/entry points to the existing CLI (`lexile_corpus_tuner.cli` lexile-scoring-model group; alias text-difficulty) and any UI modules (e.g., Gutenberg query builder) under the package.
 - Update VS Code launch/task references, docs, and automation to point to the new paths.
 - Retire `scripts/production` (no shims); all entry points live under the package.
 

--- a/docs/features/potential/promoted/2025-11-18-lexile-faithful-text-difficulty-pipeline.md
+++ b/docs/features/potential/promoted/2025-11-18-lexile-faithful-text-difficulty-pipeline.md
@@ -43,7 +43,7 @@ A new three-layer pipeline architecture that implements the Lexile framework met
 - Fit regression model (features → official Lexile measures) using sklearn
 - Export trained model as JSON specification for runtime use (no sklearn dependency at runtime)
 
-**CLI Interface**: New `text-difficulty-pipeline` command with subcommands:
+**CLI Interface**: New `lexile-scoring-model-pipeline` command with subcommands (keep `text-difficulty-pipeline` as a legacy alias):
 
 - `corpus download` - Fetch Gutenberg subset, Simple Wiki dump, OER sources
 - `corpus normalize` - Normalize and shard corpus texts

--- a/docs/features/potential/promoted/2025-12-05-pipeline-structure.md
+++ b/docs/features/potential/promoted/2025-12-05-pipeline-structure.md
@@ -13,12 +13,12 @@ Pipeline scripts for the Lexile-faithful text difficulty epic live in a `product
 
 ## Proposed Behavior
 
-Consolidate the pipeline scripts under `src/` (aligned to the `lexile-faithful-text-difficulty-pipeline` initiative), with a clear package/module layout and updated imports/entry points. Preserve behavior/CLIs while making the code discoverable, testable, and ready for packaging and future maintenance.
+Consolidate the pipeline scripts under `src/` (aligned to the `lexile-faithful-text-difficulty-pipeline` initiative), with a clear package/module layout and updated imports/entry points. Preserve behavior/CLIs while making the code discoverable, testable, and ready for packaging and future maintenance. Use `lexile-scoring-model-pipeline` as the entry point (keep `text-difficulty-pipeline` as a legacy alias if needed during transition).
 
 ## Acceptance Criteria (early draft)
 
 - [ ] `production/` is retired; scripts live under `src/lexile_corpus_tuner/...` with package init in place.
-- [ ] All moved scripts keep identical runtime behavior/CLIs; commands still reachable via existing entry points/tasks.
+- [ ] All moved scripts keep identical runtime behavior/CLIs; commands still reachable via entry points/tasks (`lexile-scoring-model-pipeline`, legacy alias `text-difficulty-pipeline`).
 - [ ] Imports/config paths updated; Black/Ruff/Pyright/Pytest clean after the move.
 - [ ] Initiative docs point to the new structure (no stale references to `production/`).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "lexile-corpus-tuner"
-version = "0.1.0"
+version = "0.1.1"
 description = "Lexile-inspired corpus tuner with CLI for analyzing and rewriting documents."
 authors = ["Lexile Corpus Tuner Maintainers"]
 license = "MIT"
@@ -43,6 +43,8 @@ llm-openai = ["openai"]
 
 [tool.poetry.scripts]
 lexile-tuner = "lexile_corpus_tuner.cli:main"
+lexile-scoring-model-pipeline = "lexile_corpus_tuner.cli:text_difficulty_cli"
+# Legacy alias kept for compatibility
 text-difficulty-pipeline = "lexile_corpus_tuner.cli:text_difficulty_cli"
 
 [tool.black]

--- a/src/lexile_corpus_tuner/cli.py
+++ b/src/lexile_corpus_tuner/cli.py
@@ -567,7 +567,7 @@ def _load_openai_key_from_script(env_name: str) -> str | None:
     return secret
 
 
-@click.group(name="text-difficulty")
+@click.group(name="lexile-scoring-model")
 def text_difficulty_cli() -> None:
     """Lexile-faithful text difficulty pipeline CLI."""
 


### PR DESCRIPTION
* Introduce `lexile-scoring-model-pipeline` as the primary entry point for the Lexile scoring model workflow, wired to `lexile_corpus_tuner.cli:text_difficulty_cli`.
* Keep `text-difficulty-pipeline` as a legacy alias to preserve existing scripts and documentation during transition.
* Rename the Click command group from `text-difficulty` to `lexile-scoring-model` to better reflect its role in the architecture.
* Bump package version from `0.1.0` to `0.1.1` to capture the new public CLI surface.
* Refresh README and feature docs to describe the new naming, flows, and roadmap while clarifying that `text-difficulty-pipeline` remains available as a compatibility alias.
* Update CI documentation and initiative/spec docs so references to the pipeline align with the new `lexile-scoring-model-pipeline` terminology.