### PR TITLE
bugfix: misspelling of development branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, develop, feature/*]
+    branches: [main, development, feature/*]
   pull_request:
-    branches: [main, develop]
+    branches: [main, development]
 
 jobs:
   quality-checks7:


### PR DESCRIPTION
This PR fixes a simple bug in the CI protocol that was preventing it from running on the development branch. By fixing the bug, it should now work.