### PR TITLE
(fix(dev-tools)): handle Copilot CLI throttling with bounded retries

### DIFF
--- a/docs/developer-tooling.md
+++ b/docs/developer-tooling.md
@@ -301,6 +301,23 @@ poetry run python -m scripts.dev_tools.atomic_executor.cli execute \
   --print-prompt
 ```
 
+### Copilot CLI throttling controls
+
+The executor self-regulates GitHub Copilot CLI usage based on **call frequency** (calls per time window), not token usage.
+
+Key flags (safe defaults):
+
+- `--copilot-cli-max-calls-per-window` (default: 6)
+- `--copilot-cli-window-seconds` (default: 60)
+- `--copilot-cli-backoff-base-seconds` (default: 2)
+- `--copilot-cli-backoff-max-seconds` (default: 60)
+- `--copilot-cli-output-tail-bytes` (default: 4096) — bounded output capture used for throttle classification
+- `--copilot-cli-max-retries` (default: 8) — bounded retries on detected throttling
+
+Platform note:
+
+- GitHub Copilot CLI native Windows PowerShell support is experimental; WSL is recommended on Windows when available.
+
 ## VS Code Integration
 
 ### Recommended Extensions

--- a/docs/features/active/2026-01-10-atomic-executor-throttling-80/plan.2026-01-10T15-21.md
+++ b/docs/features/active/2026-01-10-atomic-executor-throttling-80/plan.2026-01-10T15-21.md
@@ -21,68 +21,85 @@ last_updated: 2026-01-10
 **Plan-of-record:** This timestamped file (`plan.2026-01-10T15-21.md`) is authoritative for execution. Any references elsewhere to `plan.md` are not applicable for this feature folder.
 
 
-- [ ] [P0-T1] Read repo Copilot instructions (policy order)
+- [x] [P0-T1] Read repo Copilot instructions (policy order)
 	- Files:
 		- `.github/copilot-instructions.md`
 	- Acceptance:
 		- Confirm the repo’s policy order is understood and will be followed for this change.
 
-- [ ] [P0-T2] Read general code-change policy (toolchain loop + bugfix workflow)
+- [x] [P0-T2] Read general code-change policy (toolchain loop + bugfix workflow)
 	- Files:
 		- `.github/instructions/general-code-change.instructions.md`
 	- Acceptance:
 		- Confirm the required toolchain loop (format → lint → type-check → test) must be run until clean.
 
-- [ ] [P0-T3] Read Python code-change policy (Black/Ruff/Pyright expectations)
+- [x] [P0-T3] Read Python code-change policy (Black/Ruff/Pyright expectations)
 	- Files:
 		- `.github/instructions/python-code-change.instructions.md`
 	- Acceptance:
 		- Confirm strict typing + suppression rules are understood.
 
-- [ ] [P0-T4] Read unit test policies (no temp files; deterministic; pytest)
+- [x] [P0-T4] Read unit test policies (no temp files; deterministic; pytest)
 	- Files:
 		- `.github/instructions/general-unit-test.instructions.md`
 		- `.github/instructions/python-unit-test.instructions.md`
 	- Acceptance:
 		- Confirm tests must not write temporary files and must avoid external dependencies.
 
-- [ ] [P0-T5] Confirm authoritative docs and missing user story
+- [x] [P0-T5] Confirm authoritative docs and missing user story
 	- Notes:
 		- `spec.md` is authoritative.
 		- No `user-story.md` exists for this feature folder (expected for this bug).
 	- Acceptance:
 		- Any “user story” references are treated as “not applicable” for this feature.
 
-- [ ] [P0-T6] Branch hygiene: implement #80 on a dedicated branch
+- [x] [P0-T6] Branch hygiene: implement #80 on a dedicated branch
 	- Acceptance:
 		- Do not implement #80 on an unrelated feature branch (e.g., #73).
 		- Work occurs on a dedicated branch for #80 so review/rollback is isolated.
 
-- [ ] [P0-T7] Capture baseline toolchain status (record pass/fail)
+- [x] [P0-T7] Capture baseline toolchain status (record pass/fail)
 	- Commands (repo standard):
 		- `poetry run black .`
 		- `poetry run ruff check`
 		- `poetry run pyright`
 		- `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing`
-		- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/dev-tools/format-powershell.ps1`
-		- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/dev-tools/run-psscriptanalyzer.ps1`
-		- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/dev-tools/run-pester.ps1`
+		- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCFormat -Root ."`
+		- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCAnalyze -Root ."`
+		- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCTest -Root ."`
 	- Acceptance:
 		- Baseline is captured before changes (even if it’s already passing).
+	- Notes (captured):
+		- Python: Black PASS; Ruff PASS; Pyright PASS; Pytest(+coverage) PASS.
+		- PowerShell: PoshQC format PASS; PoshQC analyze PASS (after transient ScriptAnalyzer retry); PoshQC test PASS.
 
-- [ ] [P0-T8] Pin spec and acceptance criteria
+- [x] [P0-T8] Pin spec and acceptance criteria
 	- References:
 		- `docs/features/active/2026-01-10-atomic-executor-throttling-80/spec.md`
 	- Acceptance:
 		- This plan explicitly covers every item in the spec's **Acceptance Criteria** section.
+	- Coverage map (spec Acceptance Criteria → plan task IDs):
+		- Enforce configurable max calls per time window → [P0-T10], [P2-T2], [P3-T2], [P3-T3]
+		- Retry on detected throttling with exponential backoff + jitter (don’t fail immediately) → [P2-T3], [P3-T2], [P4-T1], [P1-T1]
+		- Call-frequency-based throttling controls (not token usage) → [P0-T10], [P3-T3], [P5-T2]
+		- Preserve strict ordering: never advance until current task completes + validates (even across retries) → [P3-T2], [P4-T1], [P1-T1]
+		- Classify failures as throttle vs non-throttle; classifier unit-tested (positive + negative samples) → [P2-T4], [P1-T2]
+		- Throttling detection does not rely on `CalledProcessError.stdout/stderr`; uses captured output tail and/or log tail parsing → [P0-T9], [P3-T1], [P3-T2]
+		- Retry behavior is bounded by configuration (no infinite loops by default) → [P0-T10], [P3-T2], [P3-T3], [P4-T2]
+		- Deterministic unit tests simulate throttling + recovery (no real Copilot CLI, no network) → [P2-T1], [P1-T1], [P4-T1], [P4-T2]
+		- User-facing configuration documented (CLI help + docs; safe defaults + Windows note) → [P3-T3], [P5-T2]
 
-- [ ] [P0-T9] Identify current Copilot invocation seam(s)
+- [x] [P0-T9] Identify current Copilot invocation seam(s)
 	- Files:
 		- `scripts/dev_tools/atomic_executor/cli.py`: `run_copilot()`, `_stream_copilot_output()`, `_execute_one_task()`
 	- Acceptance:
 		- Document (in plan notes or code comments during implementation) that `_execute_one_task()` currently retries only on QC failures, and does not handle Copilot non-zero exits.
+	- Notes (current behavior snapshot):
+		- `run_copilot()` streams output via `_stream_copilot_output()`, which raises `subprocess.CalledProcessError` when the Copilot CLI returns a non-zero exit code.
+		- `_execute_one_task()` calls `run_copilot()` outside of its QC try/except; therefore any Copilot non-zero exit currently aborts the executor run.
+		- `_execute_one_task()` retries only when `qc_runner.run_scoped()` fails (caught `subprocess.CalledProcessError`), i.e., only on scoped QC failures.
 
-- [ ] [P0-T10] Choose safe defaults and config surface (call-rate based)
+- [x] [P0-T10] Choose safe defaults and config surface (call-rate based)
 	- Defaults (initial proposal, adjust only with justification in PR):
 		- max calls per window: 6
 		- window seconds: 60
@@ -93,10 +110,13 @@ last_updated: 2026-01-10
 	- Acceptance:
 		- Defaults are conservative and bounded (no infinite retry by default).
 		- All settings are explicitly “calls per time window”, not token based.
+	- Notes (decision):
+		- Use the defaults above as the initial implementation targets.
+		- Rationale: 6 calls/minute keeps interactive pace while avoiding rapid-fire prompting that tends to trigger service-side throttling.
 
 ### Phase 1 — Regression tests (fail first)
 
-- [ ] [P1-T1] Add failing regression test: throttling does not abort run; retries instead
+- [x] [P1-T1] Add failing regression test: throttling does not abort run; retries instead
 	- New test module:
 		- `tests/scripts/dev_tools/atomic_executor/test_executor_throttle_retry_regression.py`
 	- Technique (deterministic; no real Copilot CLI):
@@ -107,21 +127,21 @@ last_updated: 2026-01-10
 		- This test fails against the current code before implementing throttling retry support.
 		- The test does not invoke the real `copilot` binary and makes no network calls.
 
-- [ ] [P1-T2] Add unit tests for throttle classifier (positive + negative cases)
+- [x] [P1-T2] Add unit tests for throttle classifier (positive + negative cases)
 	- New test module (avoid extending large existing files):
 		- `tests/scripts/dev_tools/atomic_executor/test_copilot_throttling_classifier.py`
 	- Acceptance:
 		- This test fails against the current code before implementing the classifier.
 		- Tests are deterministic (no network, no subprocess, no filesystem writes).
 
-- [ ] [P1-T3] Add unit tests for call-rate limiter scheduling (no real sleep)
+- [x] [P1-T3] Add unit tests for call-rate limiter scheduling (no real sleep)
 	- New test module:
 		- `tests/scripts/dev_tools/atomic_executor/test_copilot_rate_limiter.py`
 	- Acceptance:
 		- This test fails against the current code before implementing the limiter.
 		- Uses a fake clock + fake sleeper and asserts scheduled sleep durations.
 
-- [ ] [P1-T4] Add unit tests for exponential backoff growth + reset/decay
+- [x] [P1-T4] Add unit tests for exponential backoff growth + reset/decay
 	- New test module:
 		- `tests/scripts/dev_tools/atomic_executor/test_copilot_backoff.py`
 	- Acceptance:
@@ -131,7 +151,7 @@ last_updated: 2026-01-10
 
 ### Phase 2 — Deterministic primitives (unit-testable)
 
-- [ ] [P2-T1] Introduce an injectable Copilot runner seam (for deterministic tests)
+- [x] [P2-T1] Introduce an injectable Copilot runner seam (for deterministic tests)
 	- Files (one of the following approaches; prefer the smallest change that stays typed):
 		- Option A: `scripts/dev_tools/atomic_executor/cli.py` (add an injectable runner parameter to `run_copilot()`)
 		- Option B: new adapter module `scripts/dev_tools/atomic_executor/copilot_runner.py` used by `run_copilot()`
@@ -140,7 +160,7 @@ last_updated: 2026-01-10
 		- The seam returns enough information to support throttling classification (at minimum: exit code + output tail).
 		- The production implementation continues to stream output to console + log file as it does today.
 
-- [ ] [P2-T2] Add a call-rate limiter abstraction (queue-of-timestamps)
+- [x] [P2-T2] Add a call-rate limiter abstraction (queue-of-timestamps)
 	- Add new module (or equivalent cohesive location):
 		- `scripts/dev_tools/atomic_executor/copilot_throttling.py`
 	- Symbols (names may vary, but keep them explicit + typed):
@@ -151,7 +171,7 @@ last_updated: 2026-01-10
 		- Limiter enforces at most `max_calls` in the last `window_seconds`.
 		- Limiter uses injected `clock`/`sleeper` so tests avoid real sleeping.
 
-- [ ] [P2-T3] Add exponential backoff policy with jitter + bounded cap
+- [x] [P2-T3] Add exponential backoff policy with jitter + bounded cap
 	- Location: `scripts/dev_tools/atomic_executor/copilot_throttling.py`
 	- Symbols:
 		- `ExponentialBackoff(base_seconds: float, max_seconds: float, random_source: RandomSource)`
@@ -161,7 +181,7 @@ last_updated: 2026-01-10
 		- Backoff state increments on throttle events.
 		- Backoff resets/decays after a stable (non-throttle) period per spec intent (define explicitly in code + tests).
 
-- [ ] [P2-T4] Implement throttle classification from output tail (not exception stdout/stderr)
+- [x] [P2-T4] Implement throttle classification from output tail (not exception stdout/stderr)
 	- Location: `scripts/dev_tools/atomic_executor/copilot_throttling.py`
 	- Symbols:
 		- `classify_copilot_failure(exit_code: int, output_tail: str) -> FailureKind`
@@ -172,7 +192,7 @@ last_updated: 2026-01-10
 
 ### Phase 3 — Wire throttling policy into Copilot invocation
 
-- [ ] [P3-T1] Capture an in-memory output tail during Copilot streaming
+- [x] [P3-T1] Capture an in-memory output tail during Copilot streaming
 	- Files:
 		- `scripts/dev_tools/atomic_executor/cli.py`: `_stream_copilot_output()` (or a new helper)
 	- Acceptance:
@@ -180,7 +200,7 @@ last_updated: 2026-01-10
 		- A bounded tail buffer (bytes/characters) is retained and returned for classification.
 		- Classification does not depend on `CalledProcessError.stdout/stderr`.
 
-- [ ] [P3-T2] Add a throttle-aware retry loop around the Copilot CLI call
+- [x] [P3-T2] Add a throttle-aware retry loop around the Copilot CLI call
 	- Files:
 		- `scripts/dev_tools/atomic_executor/cli.py`: `run_copilot()` and/or `_execute_one_task()`
 	- Behavior:
@@ -191,7 +211,7 @@ last_updated: 2026-01-10
 		- Retries are bounded by a new configuration parameter (default bounded).
 		- Task ordering is preserved: the executor does not advance to QC or checkbox flipping until a Copilot invocation succeeds.
 
-- [ ] [P3-T3] Add user-facing CLI flags for throttling controls
+- [x] [P3-T3] Add user-facing CLI flags for throttling controls
 	- Files:
 		- `scripts/dev_tools/atomic_executor/cli.py`: `parse_args()` / `add_common()`
 	- Flags (names may be adjusted, but must exist and be documented in `--help`):
@@ -207,14 +227,14 @@ last_updated: 2026-01-10
 
 ### Phase 4 — Executor ordering invariants + integration tests
 
-- [ ] [P4-T1] Add unit test: executor does not advance tasks under throttle
+- [x] [P4-T1] Add unit test: executor does not advance tasks under throttle
 	- New test module:
 		- `tests/scripts/dev_tools/atomic_executor/test_executor_throttle_ordering.py`
 	- Acceptance:
 		- Verifies the executor retries within the same task loop (using the injectable Copilot runner seam).
 		- Verifies no checkbox is flipped and no next-task selection occurs until the throttled call succeeds.
 
-- [ ] [P4-T2] Add unit test: bounded retries terminate when always throttled
+- [x] [P4-T2] Add unit test: bounded retries terminate when always throttled
 	- New test module:
 		- `tests/scripts/dev_tools/atomic_executor/test_executor_throttle_bounded_retries.py`
 	- Acceptance:
@@ -222,7 +242,7 @@ last_updated: 2026-01-10
 
 ### Phase 5 — Verification + docs
 
-- [ ] [P5-T1] Run the full repo toolchain loop (format → lint → type-check → tests)
+- [x] [P5-T1] Run the full repo toolchain loop (format → lint → type-check → tests)
 	- Commands:
 		- `poetry run black .`
 		- `poetry run ruff check`
@@ -231,7 +251,7 @@ last_updated: 2026-01-10
 	- Acceptance:
 		- All four steps pass in a single final pass.
 
-- [ ] [P5-T2] Update documentation for new throttling controls
+- [x] [P5-T2] Update documentation for new throttling controls
 	- Files (choose the smallest correct surface):
 		- `docs/ci-documentation.md` and/or `docs/developer-tooling.md` and/or `README.md`
 	- Acceptance:
@@ -240,14 +260,14 @@ last_updated: 2026-01-10
 
 ### Phase 6 — PR & follow-up
 
-- [ ] [P6-T1] Prepare PR notes: rationale, risks, and validation
+- [x] [P6-T1] Prepare PR notes: rationale, risks, and validation
 	- Acceptance:
 		- Notes explicitly state: no attempt was made to trigger real throttling; behavior is covered via deterministic tests.
 		- Includes links to key tests covering classifier/limiter/backoff/order/bounded retries.
 
 ### Phase 7 — Release QC gate (must be last)
 
-- [ ] [P7-T1] Run the full repo QC gate for all languages; must pass clean
+- [x] [P7-T1] Run the full repo QC gate for all languages; must pass clean
 	- Purpose:
 		- This is the final release gate. It cannot be considered successful unless the repo is fully compliant.
 	- Preferred:
@@ -262,9 +282,9 @@ last_updated: 2026-01-10
 		- `poetry run ruff check`
 		- `poetry run pyright`
 		- `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing`
-		- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/dev-tools/format-powershell.ps1`
-		- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/dev-tools/run-psscriptanalyzer.ps1`
-		- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/dev-tools/run-pester.ps1`
+		- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCFormat -Root ."`
+		- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCAnalyze -Root ."`
+		- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCTest -Root ."`
 	- Acceptance:
 		- All checks pass in a single final pass (no lingering formatting or lint diffs).
 		- If any step changes files or fails, fix issues and restart the gate from the beginning.

--- a/docs/features/active/2026-01-10-atomic-executor-throttling-80/pr-notes.md
+++ b/docs/features/active/2026-01-10-atomic-executor-throttling-80/pr-notes.md
@@ -1,0 +1,41 @@
+# PR notes — Issue #80 (atomic_executor throttling)
+
+## Summary
+This change makes `atomic_executor` resilient to GitHub Copilot CLI throttling by:
+
+- Enforcing a configurable **call-rate limit** (calls per time window).
+- Retrying detected throttling failures with bounded **exponential backoff + jitter**.
+- Classifying throttle vs non-throttle failures using a bounded **captured output tail** (not `CalledProcessError.stdout/stderr`).
+- Preserving strict ordering: the executor does not advance tasks until the current task succeeds and scoped QC validates.
+
+## Why
+`atomic_executor` can hit Copilot CLI throttling based on **call cadence**, especially during long execute-all runs.
+
+## Risks
+- **False positives** in throttle classification could add unnecessary delays.
+- **Overly conservative defaults** may slow long runs.
+
+Mitigations:
+- Centralized, unit-tested classification logic.
+- All pacing parameters are user-configurable.
+- Retry behavior is bounded by default.
+
+## Validation
+No attempt was made to trigger real throttling. Behavior is covered via deterministic unit tests that simulate throttle → recovery.
+
+Key tests:
+- `tests/scripts/dev_tools/atomic_executor/test_copilot_throttling_classifier.py`
+- `tests/scripts/dev_tools/atomic_executor/test_copilot_rate_limiter.py`
+- `tests/scripts/dev_tools/atomic_executor/test_copilot_backoff.py`
+- `tests/scripts/dev_tools/atomic_executor/test_executor_throttle_retry_regression.py`
+- `tests/scripts/dev_tools/atomic_executor/test_executor_throttle_ordering.py`
+- `tests/scripts/dev_tools/atomic_executor/test_executor_throttle_bounded_retries.py`
+
+Commands run locally:
+- `poetry run black .`
+- `poetry run ruff check`
+- `poetry run pyright`
+- `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing`
+- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCFormat -Root ."`
+- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCAnalyze -Root ."`
+- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCTest -Root ."`

--- a/scripts/dev_tools/atomic_executor/cli.py
+++ b/scripts/dev_tools/atomic_executor/cli.py
@@ -21,6 +21,16 @@ from functools import lru_cache
 from pathlib import Path
 from typing import IO, cast
 
+from scripts.dev_tools.atomic_executor.copilot_runner import CopilotRunResult
+from scripts.dev_tools.atomic_executor.copilot_throttling import (
+    CallRateLimiter,
+    ExponentialBackoff,
+    FailureKind,
+    SystemClock,
+    SystemRandom,
+    TimeSleeper,
+    classify_copilot_failure,
+)
 from scripts.dev_tools.atomic_executor.feature_resolver import FeatureResolver
 from scripts.dev_tools.atomic_executor.plan_discovery import resolve_feature_plan
 from scripts.dev_tools.atomic_executor.plan_parser import PlanParser, PlanTask
@@ -30,6 +40,14 @@ from scripts.dev_tools.atomic_executor.qc_runner import QCRunner
 DEFAULT_PROMPT_TEMPLATE = ".github/prompts/execute-plan-template.md"
 PROTECTED_BRANCHES = {"main", "master", "development"}
 LOG_DIR = ".agent_logs"
+
+# Safe, bounded defaults for Copilot CLI throttling controls (issue #80).
+DEFAULT_COPILOT_CLI_MAX_CALLS_PER_WINDOW = 6
+DEFAULT_COPILOT_CLI_WINDOW_SECONDS = 60.0
+DEFAULT_COPILOT_CLI_BACKOFF_BASE_SECONDS = 2.0
+DEFAULT_COPILOT_CLI_BACKOFF_MAX_SECONDS = 60.0
+DEFAULT_COPILOT_CLI_OUTPUT_TAIL_BYTES = 4096
+DEFAULT_COPILOT_CLI_MAX_RETRIES = 8
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
@@ -90,6 +108,49 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
                 "Preferred AI model (Copilot CLI --model value or display name), "
                 "e.g. 'gpt-5.1-codex-max' or 'Claude Sonnet 4.5'."
             ),
+        )
+
+        sp.add_argument(
+            "--copilot-cli-max-calls-per-window",
+            type=int,
+            default=DEFAULT_COPILOT_CLI_MAX_CALLS_PER_WINDOW,
+            help=(
+                "Max Copilot CLI calls per time window "
+                "(call-rate based; not token based)."
+            ),
+        )
+        sp.add_argument(
+            "--copilot-cli-window-seconds",
+            type=float,
+            default=DEFAULT_COPILOT_CLI_WINDOW_SECONDS,
+            help="Window size in seconds for call-rate limiting.",
+        )
+        sp.add_argument(
+            "--copilot-cli-backoff-base-seconds",
+            type=float,
+            default=DEFAULT_COPILOT_CLI_BACKOFF_BASE_SECONDS,
+            help="Base seconds for exponential backoff after throttling.",
+        )
+        sp.add_argument(
+            "--copilot-cli-backoff-max-seconds",
+            type=float,
+            default=DEFAULT_COPILOT_CLI_BACKOFF_MAX_SECONDS,
+            help="Maximum seconds for exponential backoff cap after throttling.",
+        )
+        sp.add_argument(
+            "--copilot-cli-output-tail-bytes",
+            type=int,
+            default=DEFAULT_COPILOT_CLI_OUTPUT_TAIL_BYTES,
+            help=(
+                "Number of Copilot output bytes to retain as an in-memory tail for "
+                "throttling classification and error messages."
+            ),
+        )
+        sp.add_argument(
+            "--copilot-cli-max-retries",
+            type=int,
+            default=DEFAULT_COPILOT_CLI_MAX_RETRIES,
+            help="Max throttle-triggered retries per atomic task (bounded by default).",
         )
 
     sp_exec = sub.add_parser("execute", help="Execute from first unchecked or --start.")
@@ -311,7 +372,8 @@ def run_copilot(
     run_id: str,
     resume_session: bool = False,
     _idle_timeout_seconds: float | None = None,
-) -> None:
+    _output_tail_bytes: int | None = None,
+) -> CopilotRunResult:
     """
     Invoke GitHub Copilot CLI with prompt and tool permissions.
 
@@ -324,15 +386,22 @@ def run_copilot(
         run_id (str): Run id for grouping per-task artifacts.
         resume_session (bool): Reuse prior Copilot session for this task if True.
 
+    Returns:
+        CopilotRunResult: Exit code and a bounded output tail snippet.
+
     Raises:
         FileNotFoundError: If the `copilot` CLI executable is not available.
-        CalledProcessError: If Copilot CLI execution fails.
+        TimeoutError: If Copilot produces no output for the idle timeout.
 
     Side Effects:
         - Executes `copilot` CLI command
         - Writes to log file
         - Writes a per-task session share markdown file
     """
+
+    output_tail_bytes = 4096 if _output_tail_bytes is None else _output_tail_bytes
+    if output_tail_bytes < 0:
+        output_tail_bytes = 0
 
     def normalize_copilot_model(model: str) -> str:
         """
@@ -520,16 +589,19 @@ def run_copilot(
 
             decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
             idle_timeout = _resolve_idle_timeout_seconds(_idle_timeout_seconds)
-            _stream_copilot_output(
+            exit_code, output_tail = _stream_copilot_output(
                 process=process,
                 decoder=decoder,
                 log_file=f,
                 task_id=task_id,
                 idle_timeout_seconds=idle_timeout,
+                output_tail_bytes=output_tail_bytes,
             )
 
     # Post-processing: deduplicate prompt from session file
     _clean_session_file(share_path, prompt_text)
+
+    return CopilotRunResult(exit_code=exit_code, output_tail=output_tail)
 
 
 def _resolve_idle_timeout_seconds(configured: float | None) -> float | None:
@@ -567,14 +639,27 @@ def _stream_copilot_output(
     log_file: IO[str],
     task_id: str,
     idle_timeout_seconds: float | None,
-) -> None:
+    output_tail_bytes: int | None,
+) -> tuple[int, str]:
     """Stream Copilot output with hang detection.
 
     Purpose:
         Avoid silent hangs when the Copilot CLI is waiting for interactive
         input by enforcing an idle timeout on stdout activity. Terminates the
         process and raises ``TimeoutError`` when exceeded.
+
+        While streaming, retain a bounded tail buffer of the raw output bytes.
+        This tail is returned to callers for throttling classification and
+        actionable error messages.
     """
+
+    # Retain a bounded output tail in bytes so throttling classification can be
+    # performed without reading the log file or depending on exception
+    # stdout/stderr.
+    output_tail_bytes = 0 if output_tail_bytes is None else output_tail_bytes
+    if output_tail_bytes < 0:
+        output_tail_bytes = 0
+    tail_buffer = bytearray()
 
     # Cross-platform streaming approach:
     # - `selectors` / `select.select` cannot monitor pipes on Windows, and will
@@ -627,6 +712,11 @@ def _stream_copilot_output(
             if not reader_thread.is_alive() and not saw_eof:
                 saw_eof = True
         else:
+            if output_tail_bytes > 0:
+                tail_buffer.extend(item)
+                if len(tail_buffer) > output_tail_bytes:
+                    del tail_buffer[:-output_tail_bytes]
+
             text_chunk = decoder.decode(item, final=False)
             if text_chunk:
                 print(text_chunk, end="", flush=True)
@@ -659,8 +749,7 @@ def _stream_copilot_output(
         log_file.flush()
 
     return_code = process.wait()
-    if return_code != 0:
-        raise subprocess.CalledProcessError(return_code, process.args)
+    return (return_code, tail_buffer.decode("utf-8", errors="replace"))
 
 
 @lru_cache(maxsize=4)
@@ -721,7 +810,7 @@ def _log_msg(log_file: Path, msg: str) -> None:
         f.write(f"{msg}\n")
 
 
-def _execute_one_task(
+def execute_one_task(
     workspace: Path,
     cur: PlanTask,
     parser: PlanParser,
@@ -733,6 +822,10 @@ def _execute_one_task(
     feature_dir: Path,
     preferred_model: str | None,
     run_id: str,
+    copilot_rate_limiter: CallRateLimiter,
+    copilot_backoff: ExponentialBackoff,
+    copilot_max_retries: int,
+    copilot_output_tail_bytes: int,
     print_prompt: bool = False,
     copy_prompt: bool = False,
 ) -> int:
@@ -749,8 +842,17 @@ def _execute_one_task(
         prompt_template_path (Path): Path to prompt template.
         max_fix_attempts (int): Max number of retries (0 = infinite).
         feature_dir (Path): Active feature directory.
-        preferred_model (str | None): Preferred AI model name to force in Copilot CLI.
+        preferred_model (str | None): Preferred AI model name to force in Copilot
+            CLI.
         run_id (str): Run id for grouping per-task artifacts.
+        copilot_rate_limiter (CallRateLimiter): Per-run call limiter that caps the
+            number of Copilot CLI invocations per time window.
+        copilot_backoff (ExponentialBackoff): Backoff strategy used when a Copilot
+            call appears throttled.
+        copilot_max_retries (int): Max number of throttle-triggered retries per
+            atomic task.
+        copilot_output_tail_bytes (int): Number of bytes of Copilot output tail to
+            retain for failure classification.
         print_prompt (bool): If True, print prompt and return.
         copy_prompt (bool): If True, copy prompt and return.
 
@@ -802,15 +904,77 @@ def _execute_one_task(
         print(msg)
         _log_msg(log_file, f"INFO: {msg}")
 
-        run_copilot(
-            workspace=workspace,
-            prompt_text=prompt_text,
-            log_file=log_file,
-            task_id=cur.task_id,
-            preferred_model=preferred_model,
-            run_id=run_id,
-            resume_session=attempt > 1,
-        )
+        copilot_invocation = 0
+        throttle_retries = 0
+
+        # Throttle-aware Copilot invocation loop.
+        # - Rate-limit *call frequency* with the injected limiter.
+        # - On throttle-like failures, apply bounded exponential backoff and retry.
+        # - On non-throttle failures, fail fast with actionable context.
+        while True:
+            copilot_rate_limiter.acquire()
+
+            copilot_result = run_copilot(
+                workspace=workspace,
+                prompt_text=prompt_text,
+                log_file=log_file,
+                task_id=cur.task_id,
+                preferred_model=preferred_model,
+                run_id=run_id,
+                resume_session=(attempt > 1 or copilot_invocation > 0),
+                _output_tail_bytes=copilot_output_tail_bytes,
+            )
+            copilot_invocation += 1
+
+            if copilot_result.exit_code == 0:
+                # A successful Copilot run clears any accumulated throttle state.
+                copilot_backoff.on_success()
+                break
+
+            failure_kind = classify_copilot_failure(
+                exit_code=copilot_result.exit_code,
+                output_tail=copilot_result.output_tail,
+            )
+            if failure_kind is FailureKind.NON_THROTTLE:
+                err_msg = (
+                    "Copilot CLI failed (non-throttle). "
+                    f"exit_code={copilot_result.exit_code}. "
+                    f"output_tail={copilot_result.output_tail!r}"
+                )
+                print(err_msg, file=sys.stderr)
+                _log_msg(log_file, f"ERROR: {err_msg}")
+                print(f"See log: {log_file}", file=sys.stderr)
+                return 5
+
+            # Throttle-like failure: bounded retry with backoff.
+            if copilot_max_retries < 0:
+                copilot_max_retries = 0
+
+            if throttle_retries >= copilot_max_retries:
+                err_msg = (
+                    f"Copilot CLI appears throttled, but max retries "
+                    f"({copilot_max_retries}) were exhausted for task {cur.task_id}."
+                )
+                print(err_msg, file=sys.stderr)
+                _log_msg(log_file, f"ERROR: {err_msg}")
+                print(f"See log: {log_file}", file=sys.stderr)
+                return 5
+
+            delay_seconds = copilot_backoff.on_throttle()
+            throttle_retries += 1
+
+            retry_msg = (
+                f"Copilot throttled for task {cur.task_id}; retry "
+                f"{throttle_retries}/{copilot_max_retries} after "
+                f"{delay_seconds:.2f}s backoff."
+            )
+            print(retry_msg)
+            _log_msg(log_file, f"WARN: {retry_msg}")
+
+            # Apply the backoff delay using the injected sleeper so tests can
+            # remain deterministic (no real sleeps).
+            if delay_seconds > 0:
+                copilot_rate_limiter.sleeper.sleep(delay_seconds)
 
         # Refresh plan/task state after Copilot run
         cur_after = parser.find_task_by_id(cur.task_id)
@@ -932,9 +1096,25 @@ def main(argv: list[str] | None = None) -> int:
     )
     qc_runner = QCRunner(workspace)
 
+    # Per-run throttling controls. The limiter must persist across tasks to
+    # regulate overall call cadence.
+    copilot_rate_limiter = CallRateLimiter(
+        max_calls=args.copilot_cli_max_calls_per_window,
+        window_seconds=args.copilot_cli_window_seconds,
+        clock=SystemClock(),
+        sleeper=TimeSleeper(),
+    )
+
     while True:
+        # Backoff state is per-task; it resets after successful Copilot invocations.
+        copilot_backoff = ExponentialBackoff(
+            base_seconds=args.copilot_cli_backoff_base_seconds,
+            max_seconds=args.copilot_cli_backoff_max_seconds,
+            random_source=SystemRandom(),
+        )
+
         # Build prompt and execute
-        result = _execute_one_task(
+        result = execute_one_task(
             workspace=workspace,
             cur=cur,
             parser=parser,
@@ -946,6 +1126,10 @@ def main(argv: list[str] | None = None) -> int:
             feature_dir=feature_dir,
             preferred_model=args.preferred_model,
             run_id=run_id,
+            copilot_rate_limiter=copilot_rate_limiter,
+            copilot_backoff=copilot_backoff,
+            copilot_max_retries=args.copilot_cli_max_retries,
+            copilot_output_tail_bytes=args.copilot_cli_output_tail_bytes,
             print_prompt=args.print_prompt,
             copy_prompt=args.copy_prompt,
         )

--- a/scripts/dev_tools/atomic_executor/copilot_runner.py
+++ b/scripts/dev_tools/atomic_executor/copilot_runner.py
@@ -1,0 +1,38 @@
+"""Typed seams for running GitHub Copilot CLI.
+
+Purpose:
+    The atomic executor needs deterministic unit tests that can simulate Copilot
+    outcomes (success, throttling, and non-throttling failures) without invoking
+    the real `copilot` binary.
+
+    This module defines small, typed value objects and protocols that enable
+    dependency injection around Copilot execution.
+
+Notes:
+    The concrete subprocess implementation currently lives in
+    `scripts.dev_tools.atomic_executor.cli.run_copilot()`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CopilotRunResult:
+    """Result of a single Copilot CLI invocation.
+
+    Purpose:
+        Capture enough information from one Copilot call to support:
+        - throttling detection/classification
+        - retry/backoff decisions
+        - actionable error reporting
+
+    Attributes:
+        exit_code (int): Process exit code. Zero indicates success.
+        output_tail (str): A bounded tail snippet of the Copilot output stream
+            (used for classification and error messages).
+    """
+
+    exit_code: int
+    output_tail: str

--- a/scripts/dev_tools/atomic_executor/copilot_throttling.py
+++ b/scripts/dev_tools/atomic_executor/copilot_throttling.py
@@ -1,0 +1,332 @@
+"""Deterministic throttling primitives for Copilot CLI invocation.
+
+Purpose:
+    The atomic executor invokes the Copilot CLI once per atomic task attempt.
+    When invoked too quickly, the CLI or upstream services can respond with
+    throttling/rate-limit errors.
+
+    This module provides small, fully typed primitives that allow the executor
+    to self-regulate *call frequency* (calls per time window) and to apply
+    throttle-aware retries with bounded exponential backoff.
+
+Design constraints:
+    - Must be deterministic and unit-testable.
+    - Must not require real sleeps in tests (inject a sleeper).
+    - Must not require real time in tests (inject a clock).
+
+Note:
+    Higher-level orchestration (when to retry, how many times, and how to surface
+    errors) lives in the executor CLI layer.
+"""
+
+from __future__ import annotations
+
+import secrets
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Protocol
+
+
+class Clock(Protocol):
+    """Clock abstraction for deterministic time in tests.
+
+    Purpose:
+        `time.monotonic()` is not deterministic in tests. The rate limiter and
+        backoff policy depend on monotonic time, so we inject a clock.
+    """
+
+    def now_monotonic(self) -> float:
+        """Return a monotonic timestamp in seconds."""
+        ...
+
+
+class Sleeper(Protocol):
+    """Sleep abstraction for deterministic scheduling in tests.
+
+    Purpose:
+        Production code can call `time.sleep`, but tests must not do real sleeps.
+        Injecting a sleeper allows tests to record and simulate time advances.
+    """
+
+    def sleep(self, seconds: float) -> None:
+        """Sleep for the specified duration (seconds)."""
+
+
+class RandomSource(Protocol):
+    """Random source abstraction for deterministic jitter in tests.
+
+    Purpose:
+        Production uses a system randomness source. Tests must be able to provide a
+        deterministic value so backoff behavior can be asserted precisely.
+    """
+
+    def random(self) -> float:
+        """Return a random float in the interval [0.0, 1.0]."""
+        ...
+
+
+def _new_call_times() -> deque[float]:
+    """Create an empty typed deque for CallRateLimiter timestamps.
+
+    Purpose:
+        `collections.deque` is not generic at runtime, so `field(default_factory=deque)`
+        leads Pyright to infer `deque[Unknown]`. Providing a typed factory keeps the
+        dataclass field fully typed under strict settings.
+
+    Returns:
+        deque[float]: Empty deque to store monotonic call timestamps.
+    """
+
+    return deque()
+
+
+@dataclass
+class CallRateLimiter:
+    """Enforce a maximum number of calls per sliding time window.
+
+    Purpose:
+        Prevent rapid-fire Copilot CLI invocations that are likely to trigger
+        throttling. This limiter is strictly *call-count* based; it intentionally
+        does not attempt to estimate token usage.
+
+    Usage:
+        Call `acquire()` immediately before invoking Copilot.
+
+    Invariants / Constraints:
+        - `max_calls` must be >= 1.
+        - `window_seconds` must be > 0.
+        - Uses monotonic time (via `clock`) so it is unaffected by wall-clock
+          changes.
+
+    Side Effects:
+        May call `sleeper.sleep(...)` when the call budget is exhausted.
+
+    Attributes:
+        max_calls (int): Maximum number of calls permitted in the trailing window.
+        window_seconds (float): Window size in seconds.
+        clock (Clock): Injected clock source.
+        sleeper (Sleeper): Injected sleeper used for scheduling.
+    """
+
+    max_calls: int
+    window_seconds: float
+    clock: Clock
+    sleeper: Sleeper
+
+    _call_times: deque[float] = field(default_factory=_new_call_times)
+
+    def acquire(self) -> None:
+        """Block (via injected sleeper) until a call is permitted, then record it.
+
+        Purpose:
+            Enforces a sliding-window rate limit. When a call would exceed the
+            `max_calls` budget, the limiter sleeps until the oldest call falls
+            outside the window.
+
+        Raises:
+            ValueError: If configured with invalid parameters.
+
+        Side Effects:
+            May sleep (via `sleeper`) and always records a new call timestamp.
+        """
+
+        if self.max_calls < 1:
+            raise ValueError("max_calls must be >= 1")
+        if self.window_seconds <= 0:
+            raise ValueError("window_seconds must be > 0")
+
+        while True:
+            now = self.clock.now_monotonic()
+            window_start = now - self.window_seconds
+
+            # Evict timestamps that are no longer within the trailing window.
+            while self._call_times and self._call_times[0] <= window_start:
+                self._call_times.popleft()
+
+            # Under the limit: record immediately.
+            if len(self._call_times) < self.max_calls:
+                self._call_times.append(now)
+                return
+
+            # At limit: sleep until the oldest call expires.
+            oldest = self._call_times[0]
+            sleep_seconds = (oldest + self.window_seconds) - now
+
+            # Guard against clock/sleeper anomalies: treat non-positive delays as
+            # "no delay" and re-evaluate.
+            if sleep_seconds > 0:
+                self.sleeper.sleep(sleep_seconds)
+
+
+@dataclass
+class ExponentialBackoff:
+    """Exponential backoff with full jitter and a hard cap.
+
+    Purpose:
+        When a Copilot invocation is classified as throttled/rate-limited, the
+        executor should pause before retrying. Exponential backoff reduces the
+        chance of repeated throttling while preserving forward progress.
+
+    Backoff model:
+        Let $k$ be the number of throttle events observed since the last
+        successful invocation. The nominal delay is:
+
+        $$\\text{nominal} = \\text{base} \\cdot 2^k$$
+
+        The nominal delay is capped to `max_seconds` *before* jitter.
+        Full jitter means sampling uniformly from [0, cap]. With an injected
+        `RandomSource`, we compute:
+
+        $$\\text{delay} = U(0,1) \\cdot \\min(\\text{max}, \\text{nominal})$$
+
+    Invariants / Constraints:
+        - `base_seconds` must be > 0.
+        - `max_seconds` must be > 0.
+
+    Side Effects:
+        None. This class only computes delays; it does not sleep.
+
+    Attributes:
+        base_seconds (float): Base delay in seconds.
+        max_seconds (float): Maximum delay cap in seconds.
+        random_source (RandomSource): Injected random provider.
+    """
+
+    base_seconds: float
+    max_seconds: float
+    random_source: RandomSource
+
+    _throttle_count: int = 0
+
+    def on_throttle(self) -> float:
+        """Record a throttle event and return the next delay in seconds.
+
+        Returns:
+            float: Backoff delay in seconds (may be 0.0 with full jitter).
+
+        Raises:
+            ValueError: If configured with invalid parameters.
+        """
+
+        if self.base_seconds <= 0:
+            raise ValueError("base_seconds must be > 0")
+        if self.max_seconds <= 0:
+            raise ValueError("max_seconds must be > 0")
+
+        nominal = self.base_seconds * (2**self._throttle_count)
+        self._throttle_count += 1
+
+        capped = self.max_seconds if nominal > self.max_seconds else nominal
+        jitter = self.random_source.random()
+
+        # The RandomSource contract is [0, 1], but we clamp defensively to keep
+        # backoff bounded even if a caller provides a buggy implementation.
+        if jitter < 0.0:
+            jitter = 0.0
+        elif jitter > 1.0:
+            jitter = 1.0
+
+        return jitter * capped
+
+    def on_success(self) -> None:
+        """Reset backoff state after a successful (non-throttle) invocation."""
+
+        self._throttle_count = 0
+
+
+class FailureKind(Enum):
+    """Classification of a Copilot invocation failure.
+
+    Purpose:
+        The executor needs to decide whether a failure is retryable (throttle)
+        or should fail fast (non-throttle).
+    """
+
+    THROTTLE = "throttle"
+    NON_THROTTLE = "non_throttle"
+
+
+def classify_copilot_failure(*, exit_code: int, output_tail: str) -> FailureKind:
+    """Classify a Copilot CLI outcome as throttle vs non-throttle.
+
+    Purpose:
+        Copilot CLI failures are surfaced primarily via an exit code and the
+        streamed output written to the executor log. This classifier uses a
+        bounded output tail snippet so it does not depend on
+        `CalledProcessError.stdout`/`stderr`.
+
+    Args:
+        exit_code (int): Copilot CLI process exit code.
+        output_tail (str): Bounded output tail snippet (case-insensitive).
+
+    Returns:
+        FailureKind: THROTTLE when output suggests a retryable rate limit;
+            otherwise NON_THROTTLE.
+    """
+
+    # Exit code 0 is always success (non-throttle).
+    if exit_code == 0:
+        return FailureKind.NON_THROTTLE
+
+    tail = output_tail.lower()
+
+    # Match common provider/service signals. Keep this simple and explicit so it
+    # is easy to reason about in tests and logs.
+    throttle_markers = (
+        "rate limit",
+        "rate limited",
+        "throttle",
+        "too many requests",
+        "http 429",
+        " 429",
+        "429 ",
+        "(429)",
+        "http 503",
+        " 503",
+        "503 ",
+        "(503)",
+        "service unavailable",
+    )
+
+    # The decision is purely signature-based: if any marker appears in the tail,
+    # we treat it as retryable throttling.
+    for marker in throttle_markers:
+        if marker in tail:
+            return FailureKind.THROTTLE
+
+    return FailureKind.NON_THROTTLE
+
+
+@dataclass(frozen=True)
+class SystemClock:
+    """Production clock implementation using `time.monotonic()`."""
+
+    def now_monotonic(self) -> float:
+        """Return the system monotonic time in seconds."""
+
+        return time.monotonic()
+
+
+@dataclass(frozen=True)
+class TimeSleeper:
+    """Production sleeper implementation using `time.sleep()`."""
+
+    def sleep(self, seconds: float) -> None:
+        """Sleep for the specified duration."""
+
+        time.sleep(seconds)
+
+
+@dataclass(frozen=True)
+class SystemRandom:
+    """Production random source using `secrets.randbits()` (crypto-strong)."""
+
+    def random(self) -> float:
+        """Return a random float in the interval [0.0, 1.0]."""
+
+        # Produce a uniform-ish float in [0.0, 1.0) using a cryptographically
+        # strong source to satisfy security linting (even though this jitter is
+        # not used for secrets).
+        return secrets.randbits(53) / (1 << 53)

--- a/tests/scripts/dev_tools/atomic_executor/test_copilot_backoff.py
+++ b/tests/scripts/dev_tools/atomic_executor/test_copilot_backoff.py
@@ -1,0 +1,80 @@
+"""Unit tests for exponential backoff behavior (deterministic jitter).
+
+These tests specify the backoff schedule used when Copilot CLI throttling is
+classified as retryable.
+
+Note:
+    This module is expected to FAIL until the backoff implementation is
+    introduced (issue #80).
+"""
+
+from __future__ import annotations
+
+
+class _FakeRandom:
+    """Deterministic random source returning a fixed value."""
+
+    def __init__(self, value: float) -> None:
+        if not (0.0 <= value <= 1.0):
+            raise ValueError("value must be in [0, 1]")
+        self._value = value
+
+    def random(self) -> float:
+        """Return the fixed random value."""
+
+        return self._value
+
+
+def test_backoff_grows_exponentially_with_full_jitter() -> None:
+    """Delays should grow as base*2^k with full jitter, capped by max."""
+
+    from scripts.dev_tools.atomic_executor.copilot_throttling import ExponentialBackoff
+
+    backoff = ExponentialBackoff(
+        base_seconds=2.0,
+        max_seconds=60.0,
+        random_source=_FakeRandom(0.5),
+    )
+
+    # First few throttle events should yield: 2, 4, 8 nominal, each with 0.5 jitter.
+    assert backoff.on_throttle() == 1.0
+    assert backoff.on_throttle() == 2.0
+    assert backoff.on_throttle() == 4.0
+
+
+def test_backoff_caps_at_max_seconds() -> None:
+    """Backoff must cap at max_seconds before jitter is applied."""
+
+    from scripts.dev_tools.atomic_executor.copilot_throttling import ExponentialBackoff
+
+    backoff = ExponentialBackoff(
+        base_seconds=50.0,
+        max_seconds=60.0,
+        random_source=_FakeRandom(0.5),
+    )
+
+    # First throttle: nominal 50 -> jitter 25.
+    assert backoff.on_throttle() == 25.0
+
+    # Second throttle: nominal would be 100, but cap to 60 -> jitter 30.
+    assert backoff.on_throttle() == 30.0
+
+
+def test_backoff_resets_after_success() -> None:
+    """A non-throttle success should reset/decay the backoff state."""
+
+    from scripts.dev_tools.atomic_executor.copilot_throttling import ExponentialBackoff
+
+    backoff = ExponentialBackoff(
+        base_seconds=2.0,
+        max_seconds=60.0,
+        random_source=_FakeRandom(0.5),
+    )
+
+    assert backoff.on_throttle() == 1.0
+    assert backoff.on_throttle() == 2.0
+
+    backoff.on_success()
+
+    # After reset, the next throttle should behave like the first.
+    assert backoff.on_throttle() == 1.0

--- a/tests/scripts/dev_tools/atomic_executor/test_copilot_rate_limiter.py
+++ b/tests/scripts/dev_tools/atomic_executor/test_copilot_rate_limiter.py
@@ -1,0 +1,90 @@
+"""Unit tests for call-rate limiter behavior (no real sleeping).
+
+These tests define deterministic scheduling behavior for a "calls per window"
+rate limiter used by the atomic executor when invoking Copilot CLI.
+
+Note:
+    This module is expected to FAIL until the rate limiter implementation is
+    introduced (issue #80).
+"""
+
+from __future__ import annotations
+
+
+class _FakeClock:
+    """Deterministic monotonic clock for tests."""
+
+    def __init__(self, start: float) -> None:
+        self._now = start
+
+    def now_monotonic(self) -> float:
+        """Return the current monotonic time."""
+
+        return self._now
+
+    def advance(self, seconds: float) -> None:
+        """Advance the clock by a positive duration."""
+
+        if seconds < 0:
+            raise ValueError("seconds must be >= 0")
+        self._now += seconds
+
+
+class _FakeSleeper:
+    """Sleeper that records delays and advances the fake clock."""
+
+    def __init__(self, clock: _FakeClock) -> None:
+        self._clock = clock
+        self.sleeps: list[float] = []
+
+    def sleep(self, seconds: float) -> None:
+        """Record the sleep duration and advance the clock."""
+
+        if seconds < 0:
+            raise ValueError("seconds must be >= 0")
+        self.sleeps.append(seconds)
+        self._clock.advance(seconds)
+
+
+def test_rate_limiter_allows_calls_under_limit_without_sleep() -> None:
+    """Under the max-calls threshold, the limiter should not sleep."""
+
+    from scripts.dev_tools.atomic_executor.copilot_throttling import CallRateLimiter
+
+    clock = _FakeClock(start=100.0)
+    sleeper = _FakeSleeper(clock)
+
+    limiter = CallRateLimiter(
+        max_calls=2, window_seconds=10.0, clock=clock, sleeper=sleeper
+    )
+
+    limiter.acquire()
+    clock.advance(1.0)
+    limiter.acquire()
+
+    assert sleeper.sleeps == []
+
+
+def test_rate_limiter_sleeps_until_oldest_call_expires() -> None:
+    """When at the limit, a new acquire sleeps until the window permits it."""
+
+    from scripts.dev_tools.atomic_executor.copilot_throttling import CallRateLimiter
+
+    clock = _FakeClock(start=100.0)
+    sleeper = _FakeSleeper(clock)
+
+    limiter = CallRateLimiter(
+        max_calls=2, window_seconds=10.0, clock=clock, sleeper=sleeper
+    )
+
+    limiter.acquire()  # t=100
+    clock.advance(1.0)
+    limiter.acquire()  # t=101
+
+    # At t=102, the oldest call (t=100) is still within the 10s window.
+    clock.advance(1.0)
+
+    limiter.acquire()
+
+    assert sleeper.sleeps == [8.0]
+    assert clock.now_monotonic() == 110.0

--- a/tests/scripts/dev_tools/atomic_executor/test_copilot_throttling_classifier.py
+++ b/tests/scripts/dev_tools/atomic_executor/test_copilot_throttling_classifier.py
@@ -1,0 +1,75 @@
+"""Unit tests for Copilot CLI throttling classification.
+
+These tests define the expected behavior for classifying Copilot CLI failures as
+"throttle" vs "non-throttle" based on exit code and an output tail snippet.
+
+They are intentionally deterministic and do not invoke subprocesses or the
+network.
+
+Note:
+    This module is expected to FAIL until the production classifier is
+    implemented (issue #80).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("exit_code", "output_tail"),
+    [
+        (1, "Error: rate limit exceeded"),
+        (1, "RATE LIMITED: please retry"),
+        (1, "HTTP 429 Too Many Requests"),
+        (1, "Service Unavailable (503)"),
+        (1, "throttle detected, backing off"),
+    ],
+)
+def test_classify_throttle_positive_samples(exit_code: int, output_tail: str) -> None:
+    """Throttle-like tails should classify as THROTTLE."""
+
+    from scripts.dev_tools.atomic_executor.copilot_throttling import (
+        FailureKind,
+        classify_copilot_failure,
+    )
+
+    assert classify_copilot_failure(exit_code=exit_code, output_tail=output_tail) is (
+        FailureKind.THROTTLE
+    )
+
+
+@pytest.mark.parametrize(
+    ("exit_code", "output_tail"),
+    [
+        (1, "Permission denied: cannot execute"),
+        (1, "Authentication failed: invalid token"),
+        (1, "fatal: not a git repository"),
+        (1, "Unknown error occurred"),
+        (1, "Traceback (most recent call last): ..."),
+    ],
+)
+def test_classify_throttle_negative_samples(exit_code: int, output_tail: str) -> None:
+    """Non-throttle failures should classify as NON_THROTTLE."""
+
+    from scripts.dev_tools.atomic_executor.copilot_throttling import (
+        FailureKind,
+        classify_copilot_failure,
+    )
+
+    assert classify_copilot_failure(exit_code=exit_code, output_tail=output_tail) is (
+        FailureKind.NON_THROTTLE
+    )
+
+
+def test_classify_success_exit_code_is_non_throttle() -> None:
+    """Exit code 0 should never classify as THROTTLE."""
+
+    from scripts.dev_tools.atomic_executor.copilot_throttling import (
+        FailureKind,
+        classify_copilot_failure,
+    )
+
+    assert classify_copilot_failure(exit_code=0, output_tail="rate limit") is (
+        FailureKind.NON_THROTTLE
+    )

--- a/tests/scripts/dev_tools/atomic_executor/test_executor_throttle_bounded_retries.py
+++ b/tests/scripts/dev_tools/atomic_executor/test_executor_throttle_bounded_retries.py
@@ -1,0 +1,212 @@
+"""Unit test for bounded throttle retries in the atomic executor.
+
+This verifies an important requirement for issue #80:
+- Throttle-triggered retry behavior is bounded by configuration (no infinite
+  loops by default). When Copilot remains throttled, the executor must terminate
+  with a non-zero exit code after exhausting max retries.
+
+Design constraints:
+- Deterministic: no real sleeps/time/subprocess/Copilot.
+- No filesystem writes: patch logging and use in-memory fakes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+import pytest  # noqa: TCH002 - pytest required at runtime for fixtures
+
+from scripts.dev_tools.atomic_executor.copilot_runner import CopilotRunResult
+from scripts.dev_tools.atomic_executor.copilot_throttling import (
+    CallRateLimiter,
+    ExponentialBackoff,
+)
+from scripts.dev_tools.atomic_executor.plan_parser import PlanParser, PlanTask
+from scripts.dev_tools.atomic_executor.prompt_builder import PromptBuilder
+from scripts.dev_tools.atomic_executor.qc_runner import QCRunner
+
+
+def _noop_log(_log_file: Path, _msg: str) -> None:
+    """Ignore log writes from the CLI under test.
+
+    Purpose:
+        Unit tests must avoid filesystem writes. The executor logs progress to a
+        file, so we patch the logger with a typed no-op.
+    """
+
+
+class _FakeClock:
+    """Deterministic monotonic clock for tests."""
+
+    def __init__(self, start: float) -> None:
+        self._now = start
+
+    def now_monotonic(self) -> float:
+        """Return the current monotonic time."""
+
+        return self._now
+
+
+class _FakeSleeper:
+    """Sleeper that records delays (no real sleeping)."""
+
+    def __init__(self) -> None:
+        self.sleeps: list[float] = []
+
+    def sleep(self, seconds: float) -> None:
+        """Record the sleep duration."""
+
+        if seconds < 0:
+            raise ValueError("seconds must be >= 0")
+        self.sleeps.append(seconds)
+
+
+class _FakeRandom:
+    """Deterministic RandomSource for jitter."""
+
+    def __init__(self, value: float) -> None:
+        self._value = value
+
+    def random(self) -> float:
+        """Return a fixed jitter value."""
+
+        return self._value
+
+
+@dataclass
+class _FakePlanParser:
+    """Minimal PlanParser fake for bounded retry tests."""
+
+    task_after: PlanTask
+    flip_called: bool = False
+
+    def find_task_by_id(self, task_id: str) -> PlanTask:
+        """Return a fixed task model."""
+
+        _ = task_id
+        return self.task_after
+
+    def flip_checkbox(self, task_to_check: PlanTask) -> None:
+        """Record that a checkbox flip was attempted."""
+
+        _ = task_to_check
+        self.flip_called = True
+
+
+@dataclass
+class _FakePromptBuilder:
+    """Minimal PromptBuilder fake."""
+
+    prompt_text: str
+
+    def build(
+        self, feature_dir: Path, cur: PlanTask, retry_context: str | None = None
+    ) -> str:
+        """Return a stable prompt string."""
+
+        _ = feature_dir
+        _ = cur
+        _ = retry_context
+        return self.prompt_text
+
+
+@dataclass
+class _FakeQCRunner:
+    """Minimal QCRunner fake."""
+
+    scoped_calls: int = 0
+
+    def run_scoped(self) -> None:
+        """Record that scoped QC ran."""
+
+        self.scoped_calls += 1
+
+
+def test_executor_terminates_after_max_throttle_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Always-throttled Copilot calls must stop after max retries."""
+
+    from scripts.dev_tools.atomic_executor import cli
+
+    # Patch logging helper to avoid writing log files during tests.
+    monkeypatch.setattr(cli, "_log_msg", _noop_log)
+
+    copilot_calls: list[int] = []
+
+    def _fake_run_copilot(**_kwargs: object) -> CopilotRunResult:
+        """Always return a throttle-like failure without invoking subprocess."""
+
+        copilot_calls.append(1)
+        return CopilotRunResult(exit_code=1, output_tail="429 too many requests")
+
+    monkeypatch.setattr(cli, "run_copilot", _fake_run_copilot)
+
+    cur = PlanTask(
+        task_id="P3-T2",
+        phase=3,
+        task_num=2,
+        title="Add retry loop",
+        checked=False,
+        line_index=0,
+    )
+
+    task_after = PlanTask(
+        task_id=cur.task_id,
+        phase=cur.phase,
+        task_num=cur.task_num,
+        title=cur.title,
+        checked=False,
+        line_index=0,
+    )
+
+    parser = _FakePlanParser(task_after=task_after)
+    builder = _FakePromptBuilder(prompt_text="prompt")
+    qc_runner = _FakeQCRunner()
+
+    clock = _FakeClock(start=100.0)
+    sleeper = _FakeSleeper()
+    limiter = CallRateLimiter(
+        max_calls=100, window_seconds=60.0, clock=clock, sleeper=sleeper
+    )
+
+    backoff = ExponentialBackoff(
+        base_seconds=1.0,
+        max_seconds=1.0,
+        random_source=_FakeRandom(1.0),
+    )
+
+    max_retries = 2
+    exit_code = cli.execute_one_task(
+        workspace=Path("repo"),
+        cur=cur,
+        parser=cast(PlanParser, parser),
+        builder=cast(PromptBuilder, builder),
+        qc_runner=cast(QCRunner, qc_runner),
+        log_file=Path("log.txt"),
+        prompt_template_path=Path("prompt_template.md"),
+        max_fix_attempts=1,
+        feature_dir=Path("feature"),
+        preferred_model=None,
+        run_id="run",
+        copilot_rate_limiter=limiter,
+        copilot_backoff=backoff,
+        copilot_max_retries=max_retries,
+        copilot_output_tail_bytes=256,
+        print_prompt=False,
+        copy_prompt=False,
+    )
+
+    assert exit_code != 0
+
+    # With max_retries=2: attempt 1 throttled -> retry 1 (sleep)
+    # attempt 2 throttled -> retry 2 (sleep)
+    # attempt 3 throttled -> retries exhausted -> fail
+    assert len(copilot_calls) == 3
+    assert sleeper.sleeps == [1.0, 1.0]
+
+    # Executor must not run QC or flip checkboxes when Copilot never succeeds.
+    assert qc_runner.scoped_calls == 0
+    assert parser.flip_called is False

--- a/tests/scripts/dev_tools/atomic_executor/test_executor_throttle_ordering.py
+++ b/tests/scripts/dev_tools/atomic_executor/test_executor_throttle_ordering.py
@@ -1,0 +1,252 @@
+"""Unit test for executor ordering under Copilot CLI throttling.
+
+This verifies an important invariant for issue #80:
+- When a Copilot invocation is throttled, the executor retries within the same
+  task and does *not* advance the plan (checkbox flip / task completion) until a
+  Copilot invocation succeeds.
+
+Design constraints:
+- Deterministic: no real sleeps, no real time, no subprocess, no Copilot CLI.
+- No filesystem writes: we patch logging and avoid PlanParser disk operations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+import pytest  # noqa: TCH002 - pytest required at runtime for fixtures
+
+from scripts.dev_tools.atomic_executor.copilot_runner import CopilotRunResult
+from scripts.dev_tools.atomic_executor.copilot_throttling import (
+    CallRateLimiter,
+    ExponentialBackoff,
+)
+from scripts.dev_tools.atomic_executor.plan_parser import PlanParser, PlanTask
+from scripts.dev_tools.atomic_executor.prompt_builder import PromptBuilder
+from scripts.dev_tools.atomic_executor.qc_runner import QCRunner
+
+
+def _noop_log(_log_file: Path, _msg: str) -> None:
+    """Ignore log writes from the CLI under test.
+
+    Purpose:
+        Unit tests must avoid filesystem writes. The executor logs progress to a
+        file, so we patch the logger with a typed no-op.
+    """
+
+
+class _FakeClock:
+    """Deterministic monotonic clock for tests."""
+
+    def __init__(self, start: float) -> None:
+        self._now = start
+
+    def now_monotonic(self) -> float:
+        """Return the current monotonic time."""
+
+        return self._now
+
+
+class _FakeSleeper:
+    """Sleeper that records delays (no real sleeping)."""
+
+    def __init__(self, call_log: list[str]) -> None:
+        self.sleeps: list[float] = []
+        self._call_log = call_log
+
+    def sleep(self, seconds: float) -> None:
+        """Record the sleep duration."""
+
+        if seconds < 0:
+            raise ValueError("seconds must be >= 0")
+        self.sleeps.append(seconds)
+        self._call_log.append(f"sleep:{seconds}")
+
+
+class _FakeRandom:
+    """Deterministic RandomSource for jitter."""
+
+    def __init__(self, value: float) -> None:
+        self._value = value
+
+    def random(self) -> float:
+        """Return a fixed jitter value."""
+
+        return self._value
+
+
+@dataclass
+class _FakePlanParser:
+    """Minimal PlanParser fake.
+
+    Purpose:
+        Avoid filesystem writes in tests while still allowing `_execute_one_task`
+        to query task state and attempt a checkbox flip.
+
+    Attributes:
+        task_after (PlanTask): The task returned by `find_task_by_id`.
+        call_log (list[str]): Shared call log for ordering assertions.
+    """
+
+    task_after: PlanTask
+    call_log: list[str]
+
+    def find_task_by_id(self, task_id: str) -> PlanTask:
+        """Return a fixed task model (simulates reading updated plan state)."""
+
+        self.call_log.append(f"find:{task_id}")
+        return self.task_after
+
+    def flip_checkbox(self, task_to_check: PlanTask) -> None:
+        """Record a checkbox flip attempt (no disk I/O)."""
+
+        self.call_log.append(f"flip:{task_to_check.task_id}")
+
+
+@dataclass
+class _FakePromptBuilder:
+    """Minimal PromptBuilder fake.
+
+    Purpose:
+        Produce a stable prompt without reading feature folder files.
+    """
+
+    prompt_text: str
+
+    def build(
+        self, feature_dir: Path, cur: PlanTask, retry_context: str | None = None
+    ) -> str:
+        """Return a stable prompt string."""
+
+        _ = feature_dir
+        _ = cur
+        _ = retry_context
+        return self.prompt_text
+
+
+@dataclass
+class _FakeQCRunner:
+    """Minimal QCRunner fake.
+
+    Purpose:
+        Ensure QC is only run after a successful Copilot invocation.
+    """
+
+    call_log: list[str]
+
+    def run_scoped(self) -> None:
+        """Record that scoped QC ran."""
+
+        self.call_log.append("qc")
+
+
+def test_executor_does_not_flip_checkbox_until_throttle_resolves(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A throttled Copilot call must not advance the plan until success."""
+
+    from scripts.dev_tools.atomic_executor import cli
+
+    call_log: list[str] = []
+
+    # Patch logging helper to avoid writing log files during tests.
+    monkeypatch.setattr(cli, "_log_msg", _noop_log)
+
+    # Arrange a fake Copilot outcome sequence: throttle -> success.
+    outcomes = [
+        CopilotRunResult(exit_code=1, output_tail="HTTP 429 rate limit"),
+        CopilotRunResult(exit_code=0, output_tail=""),
+    ]
+
+    def _fake_run_copilot(**_kwargs: object) -> CopilotRunResult:
+        """Pop a pre-canned Copilot result without invoking any subprocess."""
+
+        call_log.append("copilot")
+        return outcomes.pop(0)
+
+    monkeypatch.setattr(cli, "run_copilot", _fake_run_copilot)
+
+    # Build a minimal task model.
+    cur = PlanTask(
+        task_id="P3-T2",
+        phase=3,
+        task_num=2,
+        title="Add retry loop",
+        checked=False,
+        line_index=0,
+    )
+
+    # After Copilot runs, executor checks plan state and flips checkbox if needed.
+    task_after = PlanTask(
+        task_id=cur.task_id,
+        phase=cur.phase,
+        task_num=cur.task_num,
+        title=cur.title,
+        checked=False,
+        line_index=0,
+    )
+
+    parser = _FakePlanParser(task_after=task_after, call_log=call_log)
+    builder = _FakePromptBuilder(prompt_text="prompt")
+    qc_runner = _FakeQCRunner(call_log=call_log)
+
+    clock = _FakeClock(start=100.0)
+    sleeper = _FakeSleeper(call_log)
+    limiter = CallRateLimiter(
+        max_calls=10, window_seconds=60.0, clock=clock, sleeper=sleeper
+    )
+
+    backoff = ExponentialBackoff(
+        base_seconds=1.0,
+        max_seconds=1.0,
+        random_source=_FakeRandom(1.0),
+    )
+
+    # Act.
+    exit_code = cli.execute_one_task(
+        workspace=Path("repo"),
+        cur=cur,
+        parser=cast(PlanParser, parser),
+        builder=cast(PromptBuilder, builder),
+        qc_runner=cast(QCRunner, qc_runner),
+        log_file=Path("log.txt"),
+        prompt_template_path=Path("prompt_template.md"),
+        max_fix_attempts=1,
+        feature_dir=Path("feature"),
+        preferred_model=None,
+        run_id="run",
+        copilot_rate_limiter=limiter,
+        copilot_backoff=backoff,
+        copilot_max_retries=3,
+        copilot_output_tail_bytes=256,
+        print_prompt=False,
+        copy_prompt=False,
+    )
+
+    # Assert.
+    assert exit_code == 0
+
+    # A single backoff sleep must occur between the two Copilot invocations.
+    assert sleeper.sleeps == [1.0]
+
+    # Ordering invariants:
+    # - Copilot is invoked twice (throttle then success).
+    # - QC and checkbox flip happen only after Copilot succeeds.
+    assert call_log.count("copilot") == 2
+    assert "qc" in call_log
+    assert any(item.startswith("flip:") for item in call_log)
+
+    first_qc_index = call_log.index("qc")
+    first_flip_index = next(
+        idx for idx, item in enumerate(call_log) if item.startswith("flip:")
+    )
+
+    # Ensure QC/flip do not occur before the second Copilot invocation.
+    # (Second invocation index is 1 because we log "copilot" for each call.)
+    second_copilot_index = [
+        idx for idx, item in enumerate(call_log) if item == "copilot"
+    ][1]
+    assert second_copilot_index < first_qc_index
+    assert first_qc_index < first_flip_index

--- a/tests/scripts/dev_tools/atomic_executor/test_executor_throttle_retry_regression.py
+++ b/tests/scripts/dev_tools/atomic_executor/test_executor_throttle_retry_regression.py
@@ -1,0 +1,246 @@
+"""Regression tests for executor behavior under simulated Copilot throttling.
+
+These tests intentionally simulate Copilot CLI failures without invoking the real
+`copilot` binary and without performing any filesystem writes.
+
+The regression covered here matches issue #80: a throttling-style Copilot failure
+should not abort the run; instead, the executor should retry the same task and
+preserve task ordering until the retry succeeds.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+import pytest  # noqa: TCH002 - pytest required at runtime for fixtures
+
+from scripts.dev_tools.atomic_executor.copilot_runner import CopilotRunResult
+from scripts.dev_tools.atomic_executor.copilot_throttling import (
+    CallRateLimiter,
+    ExponentialBackoff,
+)
+from scripts.dev_tools.atomic_executor.plan_parser import PlanParser, PlanTask
+from scripts.dev_tools.atomic_executor.prompt_builder import PromptBuilder
+from scripts.dev_tools.atomic_executor.qc_runner import QCRunner
+
+
+class _FakePromptBuilder:
+    """Deterministic prompt builder stub.
+
+    Purpose:
+        Avoid filesystem/template dependencies while exercising executor control
+        flow.
+
+    Notes:
+        This stub returns a constant prompt string. The prompt contents are
+        irrelevant to the retry behavior under test.
+    """
+
+    def build(
+        self, _feature_dir: Path, _task: PlanTask, retry_context: str | None = None
+    ) -> str:
+        """Return a stable prompt string.
+
+        Args:
+            _feature_dir (Path): Unused.
+            _task (PlanTask): Unused.
+            retry_context (str | None): Unused.
+
+        Returns:
+            str: Constant prompt text.
+        """
+
+        return "PROMPT"
+
+
+class _FakePlanParser:
+    """In-memory plan parser stub.
+
+    Purpose:
+        Avoid disk access while providing the minimal PlanParser API surface
+        used by `_execute_one_task()`.
+    """
+
+    def __init__(self, task: PlanTask) -> None:
+        self._task = task
+
+    def find_task_by_id(self, task_id: str) -> PlanTask:
+        """Return the known task by id.
+
+        Args:
+            task_id (str): Task identifier.
+
+        Returns:
+            PlanTask: The stored task.
+
+        Raises:
+            RuntimeError: If the id does not match the stored task.
+        """
+
+        if task_id != self._task.task_id:
+            raise RuntimeError(f"Unexpected task id: {task_id}")
+        return self._task
+
+    def flip_checkbox(self, _task_to_check: PlanTask) -> None:
+        """Fail if called.
+
+        Purpose:
+            The regression scenario asserts ordering (no advancement) but does
+            not need checkbox mutation. This stub intentionally fails if called
+            to ensure the test does not perform filesystem writes.
+
+        Raises:
+            AssertionError: Always.
+        """
+
+        raise AssertionError("flip_checkbox() should not be invoked in this test")
+
+
+class _FakeQCRunner:
+    """Stub QC runner.
+
+    Purpose:
+        The regression focuses on Copilot retry behavior. Scoped QC should run
+        only after a successful Copilot invocation.
+    """
+
+    def __init__(self) -> None:
+        self.scoped_runs: int = 0
+
+    def run_scoped(self) -> None:
+        """Record a scoped QC run."""
+
+        self.scoped_runs += 1
+
+
+class _StaticClock:
+    """Clock stub returning a constant monotonic time."""
+
+    def now_monotonic(self) -> float:
+        """Return a fixed monotonic timestamp."""
+
+        return 0.0
+
+
+class _NoOpSleeper:
+    """Sleeper stub that does not actually sleep."""
+
+    def sleep(self, seconds: float) -> None:
+        """No-op sleep used to keep tests deterministic."""
+
+        _ = seconds
+
+
+def _noop_log(_log_file: Path, _msg: str) -> None:
+    """Ignore log writes from the CLI under test.
+
+    Purpose:
+        The CLI implementation writes progress logs to disk. Unit tests in this
+        repo must not write temporary files, so we patch the logger with a typed
+        no-op.
+    """
+
+
+class _ZeroRandom:
+    """Random source that always returns 0.0 (full jitter -> 0 delay)."""
+
+    def random(self) -> float:
+        """Return 0.0."""
+
+        return 0.0
+
+
+def test_execute_one_task_retries_on_throttle_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Throttle->success should retry within the same task.
+
+    Scenario:
+        Simulate a Copilot outcome sequence: throttle failure on first attempt,
+        then success on the second attempt.
+
+    Expected:
+        The executor retries (calls Copilot twice) and succeeds without
+        attempting to advance to the next task.
+
+    Note:
+        This regression originally failed before issue #80 was implemented.
+    """
+
+    from scripts.dev_tools.atomic_executor import cli as cli_mod
+
+    # Arrange: prevent all filesystem writes from the code under test.
+    monkeypatch.setattr(cli_mod, "_log_msg", _noop_log)
+
+    # Arrange: create a task that is already checked so checkbox-flipping is not needed.
+    task = PlanTask(
+        task_id="P1-T1",
+        phase=1,
+        task_num=1,
+        title="regression",
+        checked=True,
+        line_index=0,
+    )
+
+    fake_parser = _FakePlanParser(task)
+    fake_builder = _FakePromptBuilder()
+    fake_qc = _FakeQCRunner()
+
+    calls: list[str] = []
+
+    def _fake_run_copilot(**_kwargs: object) -> CopilotRunResult:
+        """Simulate throttle failure once, then succeed.
+
+        Purpose:
+            The executor should treat an initial throttle-like failure as
+            retryable, so it should invoke Copilot again for the same task.
+            This behavior is implemented later in the plan.
+        """
+
+        calls.append("copilot")
+        if len(calls) == 1:
+            return CopilotRunResult(
+                exit_code=1,
+                output_tail="Error: rate limit exceeded (HTTP 429)",
+            )
+        return CopilotRunResult(exit_code=0, output_tail="")
+
+    monkeypatch.setattr(cli_mod, "run_copilot", _fake_run_copilot)
+
+    # Arrange: throttling policy inputs (fully deterministic; no real sleeps).
+    copilot_rate_limiter = CallRateLimiter(
+        max_calls=100,
+        window_seconds=60.0,
+        clock=_StaticClock(),
+        sleeper=_NoOpSleeper(),
+    )
+    copilot_backoff = ExponentialBackoff(
+        base_seconds=1.0,
+        max_seconds=1.0,
+        random_source=_ZeroRandom(),
+    )
+
+    # Act: attempt to execute the task.
+    exit_code = cli_mod.execute_one_task(
+        workspace=Path("/repo"),  # noqa: S108 - test fixture path
+        cur=task,
+        parser=cast(PlanParser, fake_parser),
+        builder=cast(PromptBuilder, fake_builder),
+        qc_runner=cast(QCRunner, fake_qc),
+        log_file=Path("/dev/null"),  # noqa: S108 - test fixture path
+        prompt_template_path=Path("/template.md"),  # noqa: S108 - test fixture path
+        max_fix_attempts=3,
+        feature_dir=Path("/feature"),  # noqa: S108 - test fixture path
+        preferred_model=None,
+        run_id="run",
+        copilot_rate_limiter=copilot_rate_limiter,
+        copilot_backoff=copilot_backoff,
+        copilot_max_retries=2,
+        copilot_output_tail_bytes=4096,
+    )
+
+    # Assert: success and expected sequencing.
+    assert exit_code == 0
+    assert calls == ["copilot", "copilot"]
+    assert fake_qc.scoped_runs == 1

--- a/tests/scripts/dev_tools/test_atomic_executor_cli.py
+++ b/tests/scripts/dev_tools/test_atomic_executor_cli.py
@@ -16,6 +16,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from scripts.dev_tools.atomic_executor.cli import main
+from scripts.dev_tools.atomic_executor.copilot_runner import CopilotRunResult
 from scripts.dev_tools.atomic_executor.plan_parser import PlanTask
 
 
@@ -53,6 +54,9 @@ def mock_dependencies() -> Generator[dict[str, Any], None, None]:
 
         resolver_instance = MockResolver.return_value
         resolver_instance.resolve.return_value = (Mock(), Path("/mock/feature/dir"))
+
+        # Treat Copilot CLI as succeeding so tests can focus on QC retry orchestration.
+        MockRunCopilot.return_value = CopilotRunResult(exit_code=0, output_tail="")
 
         yield {
             "parser_cls": MockParser,
@@ -210,8 +214,8 @@ def test_execute_all_aborts_with_exit_code_5_on_persistent_failure(
     mocks["parser"].next_unchecked_task.side_effect = [task1, task2]
     mocks["parser"].phase_complete.return_value = False
 
-    # Mock _execute_one_task to return 0 (Task1 success) then 5 (Task2 recurring fail)
-    with patch("scripts.dev_tools.atomic_executor.cli._execute_one_task") as mock_exec:
+    # Mock execute_one_task to return 0 (Task1 success) then 5 (Task2 recurring fail)
+    with patch("scripts.dev_tools.atomic_executor.cli.execute_one_task") as mock_exec:
         mock_exec.side_effect = [0, 5]
 
         # In execute-all mode


### PR DESCRIPTION
# Closes Issue #80 (atomic_executor throttling)

## Summary
This change makes `atomic_executor` resilient to GitHub Copilot CLI throttling by:

- Enforcing a configurable **call-rate limit** (calls per time window).
- Retrying detected throttling failures with bounded **exponential backoff + jitter**.
- Classifying throttle vs non-throttle failures using a bounded **captured output tail** (not `CalledProcessError.stdout/stderr`).
- Preserving strict ordering: the executor does not advance tasks until the current task succeeds and scoped QC validates.

## Why
`atomic_executor` can hit Copilot CLI throttling based on **call cadence**, especially during long execute-all runs.

## Risks
- **False positives** in throttle classification could add unnecessary delays.
- **Overly conservative defaults** may slow long runs.

Mitigations:
- Centralized, unit-tested classification logic.
- All pacing parameters are user-configurable.
- Retry behavior is bounded by default.

## Validation
No attempt was made to trigger real throttling. Behavior is covered via deterministic unit tests that simulate throttle → recovery.

Key tests:
- `tests/scripts/dev_tools/atomic_executor/test_copilot_throttling_classifier.py`
- `tests/scripts/dev_tools/atomic_executor/test_copilot_rate_limiter.py`
- `tests/scripts/dev_tools/atomic_executor/test_copilot_backoff.py`
- `tests/scripts/dev_tools/atomic_executor/test_executor_throttle_retry_regression.py`
- `tests/scripts/dev_tools/atomic_executor/test_executor_throttle_ordering.py`
- `tests/scripts/dev_tools/atomic_executor/test_executor_throttle_bounded_retries.py`

Commands run locally:
- `poetry run black .`
- `poetry run ruff check`
- `poetry run pyright`
- `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing`
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCFormat -Root ."`
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCAnalyze -Root ."`
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCTest -Root ."`