### PR TITLE
Add automatic Simple Wiki .bz2 → .xml extraction with tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,12 @@ poetry run python -m lexile_corpus_tuner.lexile_scoring_model.pipeline_scripts.b
 poetry run lexile-scoring-model-pipeline corpus download
 
 # 2) Convert Simple Wiki dump to JSONL articles
+# The download step writes both `.xml.bz2` and extracted `.xml` files.
+# The extractor accepts either format.
 poetry run python -m lexile_corpus_tuner.lexile_scoring_model.pipeline_scripts.extract_simple_wiki_dump \
-  --dump data/corpus/raw/simple_wiki/simplewiki-latest-pages-articles.xml.bz2 \
+  --dump data/corpus/raw/simple_wiki/simplewiki-latest-pages-articles.xml \
   --output data/corpus/raw/simple_wiki/simplewiki_articles.jsonl
+# (You can also pass the `.xml.bz2` path if you want to stream the archive.)
 
 # 3) Normalize & shard (shared tokenizer/normalizer)
 poetry run lexile-scoring-model-pipeline corpus normalize --shard-size-tokens 100000

--- a/docs/source-curation-guide.md
+++ b/docs/source-curation-guide.md
@@ -142,7 +142,20 @@ Run the pipeline to fetch the dump.
 poetry run lexile-scoring-model-pipeline corpus download --sources "simple_wiki"
 ```
 
-*   **Output:** The compressed dump is saved to `data/corpus/raw/simple_wiki/`.
+*   **Output:** The compressed `.bz2` dump and extracted `.xml` file are saved to
+    `data/corpus/raw/simple_wiki/`.
+
+### Step 3: Extract Articles
+
+Use the extracted XML file to build the JSONL article list (the extractor also
+accepts the `.bz2` file if you prefer streaming the archive).
+
+**Command:**
+```bash
+poetry run python -m lexile_corpus_tuner.lexile_scoring_model.pipeline_scripts.extract_simple_wiki_dump \
+  --dump data/corpus/raw/simple_wiki/simplewiki-latest-pages-articles.xml \
+  --output data/corpus/raw/simple_wiki/simplewiki_articles.jsonl
+```
 
 ---
 

--- a/src/lexile_corpus_tuner/lexile_scoring_model/corpus/download.py
+++ b/src/lexile_corpus_tuner/lexile_scoring_model/corpus/download.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import bz2
 import json
 import logging
 import os
@@ -78,6 +79,26 @@ def download_gutenberg_subset(limit: int | None = None) -> None:
 def download_simple_wiki_dump(dump_url: str | None = None) -> Path:
     """
     Download a Simple English Wikipedia XML dump into RAW_ROOT/'simple_wiki'.
+
+    Purpose:
+        Ensure both the compressed `.bz2` dump and an extracted `.xml` file are
+        present for downstream processing.
+
+    Args:
+        dump_url (str | None): Optional override for the dump URL. When omitted,
+            the environment variable `LEXILE_SIMPLE_WIKI_DUMP_URL` or the
+            default Simple Wiki URL is used.
+
+    Returns:
+        Path: The path to the downloaded `.bz2` archive.
+
+    Raises:
+        requests.RequestException: If the download fails.
+        OSError: If extraction fails to write or replace the XML output.
+
+    Side Effects:
+        Creates the raw corpus directory, downloads the dump if needed, and
+        writes an extracted XML file alongside the `.bz2` archive.
     """
     ensure_dirs()
     if dump_url is None:
@@ -85,13 +106,37 @@ def download_simple_wiki_dump(dump_url: str | None = None) -> Path:
             "LEXILE_SIMPLE_WIKI_DUMP_URL", DEFAULT_SIMPLE_WIKI_URL
         )
     filename = dump_url.split("/")[-1] or "simplewiki_dump.xml.bz2"
-    dest = SIMPLE_WIKI_DIR / filename
-    if dest.exists():
-        LOGGER.info("Simple Wiki dump already exists at %s; skipping.", dest)
-        return dest
-    LOGGER.info("Downloading Simple Wiki dump from %s", dump_url)
-    _download_file(dump_url, dest)
-    return dest
+    bz2_path = SIMPLE_WIKI_DIR / filename
+    xml_path = bz2_path.with_suffix(".xml")
+    # Branch by artifact state:
+    # - If bz2 exists and XML is non-empty, skip extraction.
+    # - If bz2 exists but XML is missing/empty, extract.
+    # - If bz2 is missing, download then extract.
+    if bz2_path.exists():
+        if xml_path.exists():
+            xml_size = xml_path.stat().st_size
+            if xml_size > 0:
+                LOGGER.info(
+                    "Skipping Simple Wiki extraction for %s because XML exists at %s "
+                    "(size=%s).",
+                    bz2_path,
+                    xml_path,
+                    xml_size,
+                )
+                return bz2_path
+        LOGGER.info(
+            "Simple Wiki dump already exists at %s; extracting XML to %s.",
+            bz2_path,
+            xml_path,
+        )
+        _extract_simple_wiki_bz2(bz2_path)
+        return bz2_path
+
+    LOGGER.info("Downloading Simple Wiki dump from %s to %s", dump_url, bz2_path)
+    _download_file(dump_url, bz2_path)
+    LOGGER.info("Extracting Simple Wiki dump from %s to %s", bz2_path, xml_path)
+    _extract_simple_wiki_bz2(bz2_path)
+    return bz2_path
 
 
 def download_oer_sources() -> None:
@@ -227,3 +272,41 @@ def _copy_local_file(src: Path, dest: Path) -> None:
         raise FileNotFoundError(f"Source file not found: {src}")
     dest.parent.mkdir(parents=True, exist_ok=True)
     shutil.copyfile(src, dest)
+
+
+def _extract_simple_wiki_bz2(bz2_path: Path) -> Path:
+    """
+    Extract a Simple Wiki `.bz2` archive to a `.xml` file via streaming copy.
+
+    Purpose:
+        Materialize a plain XML dump from the compressed `.bz2` archive while
+        keeping memory usage bounded and writes atomic.
+
+    Args:
+        bz2_path (Path): Path to the `.bz2` archive to decompress.
+
+    Returns:
+        Path: The extracted `.xml` file path.
+
+    Raises:
+        OSError: If reading, writing, or replacing files fails.
+        EOFError: If the `.bz2` stream is truncated.
+        RuntimeError: If decompression fails due to invalid input.
+
+    Side Effects:
+        Writes a temporary XML file, then atomically replaces the final XML
+        destination; cleans up the temp file on errors.
+    """
+    xml_path = bz2_path.with_suffix(".xml")
+    tmp_path = xml_path.with_suffix(".xml.tmp")
+    try:
+        # Stream-decompress to a temp path to avoid loading the full dump in memory.
+        with bz2.open(bz2_path, "rb") as source, tmp_path.open("wb") as target:
+            shutil.copyfileobj(source, target, length=1 << 20)
+        tmp_path.replace(xml_path)
+    except Exception:
+        # Clean up temp output so retries are safe and idempotent.
+        if tmp_path.exists():
+            tmp_path.unlink()
+        raise
+    return xml_path

--- a/tests/src/lexile_corpus_tuner/lexile_scoring_model/corpus/test_corpus_download.py
+++ b/tests/src/lexile_corpus_tuner/lexile_scoring_model/corpus/test_corpus_download.py
@@ -6,8 +6,11 @@ All network calls are mocked to ensure tests run without internet access.
 
 from __future__ import annotations
 
+import io
 import json
 import logging
+from pathlib import Path
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, Mock, patch
 
@@ -16,8 +19,6 @@ import requests
 from lexile_corpus_tuner.lexile_scoring_model.corpus import download
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from pytest import MonkeyPatch
 
 
@@ -564,8 +565,15 @@ class TestDownloadSimpleWikiDump:
     """Tests for download_simple_wiki_dump function."""
 
     @patch("lexile_corpus_tuner.lexile_scoring_model.corpus.download._download_file")
+    @patch(
+        "lexile_corpus_tuner.lexile_scoring_model.corpus.download._extract_simple_wiki_bz2"
+    )
     def test_downloads_from_provided_url(
-        self, mock_download: Mock, tmp_path: Path, monkeypatch: MonkeyPatch
+        self,
+        mock_extract: Mock,
+        mock_download: Mock,
+        tmp_path: Path,
+        monkeypatch: MonkeyPatch,
     ) -> None:
         """Test that dump is downloaded from provided URL."""
         # Arrange
@@ -583,11 +591,19 @@ class TestDownloadSimpleWikiDump:
 
         # Assert
         mock_download.assert_called_once()
+        mock_extract.assert_called_once()
         assert result == wiki_dir / "wiki_dump.xml.bz2"
 
     @patch("lexile_corpus_tuner.lexile_scoring_model.corpus.download._download_file")
+    @patch(
+        "lexile_corpus_tuner.lexile_scoring_model.corpus.download._extract_simple_wiki_bz2"
+    )
     def test_uses_default_url_when_none_provided(
-        self, mock_download: Mock, tmp_path: Path, monkeypatch: MonkeyPatch
+        self,
+        mock_extract: Mock,
+        mock_download: Mock,
+        tmp_path: Path,
+        monkeypatch: MonkeyPatch,
     ) -> None:
         """Test that default URL is used when none is provided."""
         # Arrange
@@ -604,12 +620,20 @@ class TestDownloadSimpleWikiDump:
 
         # Assert
         mock_download.assert_called_once()
+        mock_extract.assert_called_once()
         call_url: str = mock_download.call_args[0][0]
         assert "wikimedia.org" in call_url
 
     @patch("lexile_corpus_tuner.lexile_scoring_model.corpus.download._download_file")
+    @patch(
+        "lexile_corpus_tuner.lexile_scoring_model.corpus.download._extract_simple_wiki_bz2"
+    )
     def test_uses_environment_variable_url(
-        self, mock_download: Mock, tmp_path: Path, monkeypatch: MonkeyPatch
+        self,
+        mock_extract: Mock,
+        mock_download: Mock,
+        tmp_path: Path,
+        monkeypatch: MonkeyPatch,
     ) -> None:
         """Test that environment variable URL is used when set."""
         # Arrange
@@ -626,6 +650,7 @@ class TestDownloadSimpleWikiDump:
 
         # Assert
         mock_download.assert_called_once()
+        mock_extract.assert_called_once()
         call_url: str = mock_download.call_args[0][0]
         assert call_url == "http://custom.url/dump.bz2"
 
@@ -645,7 +670,9 @@ class TestDownloadSimpleWikiDump:
         monkeypatch.setattr(download, "SIMPLE_WIKI_DIR", wiki_dir)
 
         mock_download = MagicMock()
+        mock_extract = MagicMock()
         monkeypatch.setattr(download, "_download_file", mock_download)
+        monkeypatch.setattr(download, "_extract_simple_wiki_bz2", mock_extract)
 
         # Act
         with caplog.at_level(logging.INFO):
@@ -655,12 +682,20 @@ class TestDownloadSimpleWikiDump:
 
         # Assert
         mock_download.assert_not_called()
+        mock_extract.assert_called_once_with(wiki_dir / "existing.xml.bz2")
         assert "already exists" in caplog.text
         assert result == wiki_dir / "existing.xml.bz2"
 
     @patch("lexile_corpus_tuner.lexile_scoring_model.corpus.download._download_file")
+    @patch(
+        "lexile_corpus_tuner.lexile_scoring_model.corpus.download._extract_simple_wiki_bz2"
+    )
     def test_handles_url_without_filename(
-        self, mock_download: Mock, tmp_path: Path, monkeypatch: MonkeyPatch
+        self,
+        mock_extract: Mock,
+        mock_download: Mock,
+        tmp_path: Path,
+        monkeypatch: MonkeyPatch,
     ) -> None:
         """Test that fallback filename is used for URLs without filename."""
         # Arrange
@@ -675,7 +710,653 @@ class TestDownloadSimpleWikiDump:
         result = download.download_simple_wiki_dump("http://example.com/")
 
         # Assert
+        mock_download.assert_called_once()
+        mock_extract.assert_called_once()
         assert result.name == "simplewiki_dump.xml.bz2"
+
+
+class NonClosingBytesIO(io.BytesIO):
+    """
+    BytesIO variant that keeps the buffer accessible after context-manager exits.
+
+    Purpose:
+        Provide an in-memory stream that behaves like a file handle but does not
+        close so tests can inspect written bytes after `with` blocks.
+
+    Usage:
+        Use this in tests that need to read back data written by the code under
+        test without touching the filesystem.
+
+    Flow:
+        Return this object from monkeypatched Path.open calls and inspect
+        `.getvalue()` after the helper completes.
+
+    Invariants / Constraints:
+        Closing is intentionally suppressed; callers must not rely on close
+        side-effects for cleanup.
+
+    Side Effects:
+        None. This is an in-memory test helper.
+    """
+
+    def close(self) -> None:
+        """
+        Prevent closing so tests can inspect the buffer after writes.
+
+        Purpose:
+            Override the default close behavior to keep the in-memory buffer
+            readable after context-manager exits.
+
+        Args:
+            None.
+
+        Returns:
+            None: This method intentionally does not close the buffer.
+
+        Raises:
+            None.
+
+        Side Effects:
+            Leaves the buffer open so `.getvalue()` remains available.
+        """
+
+
+class TestExtractSimpleWikiBz2:
+    """Tests for _extract_simple_wiki_bz2 helper."""
+
+    def test_extract_simple_wiki_bz2_writes_xml_and_replaces_temp(
+        self, monkeypatch: MonkeyPatch
+    ) -> None:
+        """
+        Verify the helper streams content and atomically replaces the XML.
+
+        Purpose:
+            Ensure `_extract_simple_wiki_bz2` writes the decompressed payload to
+            a temp file and replaces it with the final XML path.
+
+        Args:
+            monkeypatch (MonkeyPatch): Pytest monkeypatch fixture for stubbing
+                file operations.
+
+        Returns:
+            None.
+
+        Raises:
+            AssertionError: If the helper does not copy data or replace paths.
+
+        Side Effects:
+            Uses in-memory streams to simulate file I/O.
+        """
+        # Arrange
+        bz2_path = Path(
+            "data/corpus/raw/simple_wiki/simplewiki-latest-pages-articles.xml.bz2"
+        )
+        xml_path = bz2_path.with_suffix(".xml")
+        tmp_path = xml_path.with_suffix(".xml.tmp")
+        source_stream = io.BytesIO(b"<mediawiki>payload</mediawiki>")
+        temp_stream = NonClosingBytesIO()
+        replaced_paths: list[tuple[Path, Path]] = []
+
+        def fake_bz2_open(path: Path, mode: str) -> io.BytesIO:
+            """
+            Return a reusable in-memory source stream for the bz2 payload.
+
+            Purpose:
+                Provide a deterministic source stream for the extraction helper.
+
+            Args:
+                path (Path): Expected bz2 path for the dump.
+                mode (str): Open mode; must be binary read.
+
+            Returns:
+                io.BytesIO: The in-memory stream containing the bz2 payload.
+
+            Raises:
+                AssertionError: If path or mode are unexpected.
+
+            Side Effects:
+                Resets the stream position to the beginning.
+            """
+            assert path == bz2_path
+            assert mode == "rb"
+            source_stream.seek(0)
+            return source_stream
+
+        def fake_open(
+            path: Path, mode: str = "r", *args: Any, **kwargs: Any
+        ) -> NonClosingBytesIO:
+            """
+            Return an in-memory buffer for the temporary XML output.
+
+            Purpose:
+                Replace filesystem writes with a controllable buffer.
+
+            Args:
+                path (Path): Expected temp XML path.
+                mode (str): Open mode; must be binary write.
+                *args (Any): Unused positional arguments from Path.open.
+                **kwargs (Any): Unused keyword arguments from Path.open.
+
+            Returns:
+                NonClosingBytesIO: The buffer that captures written bytes.
+
+            Raises:
+                AssertionError: If path or mode are unexpected.
+
+            Side Effects:
+                Clears any previous contents from the buffer.
+            """
+            assert path == tmp_path
+            assert mode == "wb"
+            temp_stream.seek(0)
+            temp_stream.truncate(0)
+            return temp_stream
+
+        def fake_replace(path: Path, target: Path) -> Path:
+            """
+            Record the atomic replace call for later assertions.
+
+            Purpose:
+                Capture the temp and final XML paths used for replacement.
+
+            Args:
+                path (Path): The temp path being replaced.
+                target (Path): The final XML path.
+
+            Returns:
+                Path: The target path to mimic Path.replace behavior.
+
+            Raises:
+                None.
+
+            Side Effects:
+                Appends the replacement tuple to `replaced_paths`.
+            """
+            replaced_paths.append((path, target))
+            return target
+
+        monkeypatch.setattr(download.bz2, "open", fake_bz2_open)
+        monkeypatch.setattr(Path, "open", fake_open)
+        monkeypatch.setattr(Path, "replace", fake_replace)
+
+        # Act
+        extract_fn = (
+            download._extract_simple_wiki_bz2  # pyright: ignore[reportPrivateUsage]
+        )
+        result = extract_fn(bz2_path)
+
+        # Assert
+        assert result == xml_path
+        assert temp_stream.getvalue() == b"<mediawiki>payload</mediawiki>"
+        assert replaced_paths == [(tmp_path, xml_path)]
+
+    def test_extract_simple_wiki_bz2_cleans_temp_on_error(
+        self, monkeypatch: MonkeyPatch
+    ) -> None:
+        """
+        Verify the helper removes temp output when extraction fails.
+
+        Purpose:
+            Ensure `_extract_simple_wiki_bz2` deletes the temporary XML file
+            when a copy error occurs and re-raises the exception.
+
+        Args:
+            monkeypatch (MonkeyPatch): Pytest monkeypatch fixture for stubbing
+                file operations and failure injection.
+
+        Returns:
+            None.
+
+        Raises:
+            AssertionError: If cleanup or error propagation fails.
+
+        Side Effects:
+            Uses in-memory streams to simulate file I/O.
+        """
+        # Arrange
+        bz2_path = Path(
+            "data/corpus/raw/simple_wiki/simplewiki-latest-pages-articles.xml.bz2"
+        )
+        xml_path = bz2_path.with_suffix(".xml")
+        tmp_path = xml_path.with_suffix(".xml.tmp")
+        source_stream = io.BytesIO(b"broken payload")
+        temp_stream = NonClosingBytesIO()
+        deleted_paths: list[Path] = []
+        replaced_paths: list[Path] = []
+
+        def fake_bz2_open(path: Path, mode: str) -> io.BytesIO:
+            """
+            Return a deterministic in-memory source stream for extraction.
+
+            Purpose:
+                Provide a predictable input stream for the failure scenario.
+
+            Args:
+                path (Path): Expected bz2 path for the dump.
+                mode (str): Open mode; must be binary read.
+
+            Returns:
+                io.BytesIO: The in-memory stream containing the bz2 payload.
+
+            Raises:
+                AssertionError: If path or mode are unexpected.
+
+            Side Effects:
+                Resets the stream position to the beginning.
+            """
+            assert path == bz2_path
+            assert mode == "rb"
+            source_stream.seek(0)
+            return source_stream
+
+        def fake_open(
+            path: Path, mode: str = "r", *args: Any, **kwargs: Any
+        ) -> NonClosingBytesIO:
+            """
+            Return an in-memory buffer for the temp XML output.
+
+            Purpose:
+                Replace filesystem writes during the failing extraction.
+
+            Args:
+                path (Path): Expected temp XML path.
+                mode (str): Open mode; must be binary write.
+                *args (Any): Unused positional arguments from Path.open.
+                **kwargs (Any): Unused keyword arguments from Path.open.
+
+            Returns:
+                NonClosingBytesIO: The buffer that would receive output.
+
+            Raises:
+                AssertionError: If path or mode are unexpected.
+
+            Side Effects:
+                Clears any previous contents from the buffer.
+            """
+            assert path == tmp_path
+            assert mode == "wb"
+            temp_stream.seek(0)
+            temp_stream.truncate(0)
+            return temp_stream
+
+        def fake_copyfileobj(
+            source: io.BufferedReader, dest: io.BufferedWriter, length: int = 0
+        ) -> None:
+            """
+            Raise an error to simulate a copy failure.
+
+            Purpose:
+                Force `_extract_simple_wiki_bz2` into its cleanup path.
+
+            Args:
+                source (io.BufferedReader): Source stream (unused).
+                dest (io.BufferedWriter): Destination stream (unused).
+                length (int): Chunk size requested by caller (unused).
+
+            Returns:
+                None.
+
+            Raises:
+                RuntimeError: Always raised to simulate failure.
+
+            Side Effects:
+                None.
+            """
+            raise RuntimeError("copy failed")
+
+        def fake_exists(path: Path) -> bool:
+            """
+            Report whether the temp path exists for cleanup checks.
+
+            Purpose:
+                Ensure the helper believes the temp path exists so it attempts
+                cleanup.
+
+            Args:
+                path (Path): Path to check.
+
+            Returns:
+                bool: True only for the temp path.
+
+            Raises:
+                None.
+
+            Side Effects:
+                None.
+            """
+            return path == tmp_path
+
+        def fake_unlink(path: Path) -> None:
+            """
+            Record temp-path deletion attempts.
+
+            Purpose:
+                Capture cleanup behavior for assertions.
+
+            Args:
+                path (Path): Path scheduled for deletion.
+
+            Returns:
+                None.
+
+            Raises:
+                None.
+
+            Side Effects:
+                Adds the deleted path to `deleted_paths`.
+            """
+            deleted_paths.append(path)
+
+        def fake_replace(path: Path, target: Path) -> Path:
+            """
+            Record replace attempts to ensure they do not occur.
+
+            Purpose:
+                Track whether the helper incorrectly performed a replace
+                during a failed extraction.
+
+            Args:
+                path (Path): Temp path involved in replace.
+                target (Path): Target path for replace.
+
+            Returns:
+                Path: The target path, to mimic Path.replace.
+
+            Raises:
+                None.
+
+            Side Effects:
+                Appends the temp path to `replaced_paths`.
+            """
+            replaced_paths.append(path)
+            return target
+
+        monkeypatch.setattr(download.bz2, "open", fake_bz2_open)
+        monkeypatch.setattr(Path, "open", fake_open)
+        monkeypatch.setattr(download.shutil, "copyfileobj", fake_copyfileobj)
+        monkeypatch.setattr(Path, "exists", fake_exists)
+        monkeypatch.setattr(Path, "unlink", fake_unlink)
+        monkeypatch.setattr(Path, "replace", fake_replace)
+
+        # Act / Assert
+        extract_fn = (
+            download._extract_simple_wiki_bz2  # pyright: ignore[reportPrivateUsage]
+        )
+        with pytest.raises(RuntimeError, match="copy failed"):
+            extract_fn(bz2_path)
+
+        assert deleted_paths == [tmp_path]
+        assert replaced_paths == []
+
+    def test_download_simple_wiki_dump_skips_extraction_when_xml_exists(
+        self, monkeypatch: MonkeyPatch
+    ) -> None:
+        """
+        Verify download skips extraction when XML already exists.
+
+        Purpose:
+            Confirm that a non-empty XML file causes the download flow to skip
+            extraction and downloading.
+
+        Args:
+            monkeypatch (MonkeyPatch): Pytest monkeypatch fixture for stubbing
+                filesystem checks and helper functions.
+
+        Returns:
+            None.
+
+        Raises:
+            AssertionError: If extraction or download is invoked unexpectedly.
+
+        Side Effects:
+            Patches filesystem calls to avoid real disk access.
+        """
+        # Arrange
+        bz2_path = Path(
+            "data/corpus/raw/simple_wiki/simplewiki-latest-pages-articles.xml.bz2"
+        )
+        xml_path = bz2_path.with_suffix(".xml")
+        extract_mock = MagicMock()
+        download_mock = MagicMock()
+
+        def fake_exists(path: Path) -> bool:
+            """
+            Pretend both bz2 and XML paths exist.
+
+            Purpose:
+                Provide deterministic existence checks for the skip branch.
+
+            Args:
+                path (Path): Path to check.
+
+            Returns:
+                bool: True for bz2 and XML paths.
+
+            Raises:
+                None.
+
+            Side Effects:
+                None.
+            """
+            return path in {bz2_path, xml_path}
+
+        def fake_stat(path: Path) -> SimpleNamespace:
+            """
+            Return a non-zero size for XML to trigger the skip branch.
+
+            Purpose:
+                Simulate a valid, non-empty XML file.
+
+            Args:
+                path (Path): Path to stat.
+
+            Returns:
+                SimpleNamespace: Object with an st_size attribute.
+
+            Raises:
+                None.
+
+            Side Effects:
+                None.
+            """
+            if path == xml_path:
+                return SimpleNamespace(st_size=100)
+            return SimpleNamespace(st_size=0)
+
+        monkeypatch.setattr(download, "ensure_dirs", lambda: None)
+        monkeypatch.setattr(download, "SIMPLE_WIKI_DIR", bz2_path.parent)
+        monkeypatch.setattr(Path, "exists", fake_exists)
+        monkeypatch.setattr(Path, "stat", fake_stat)
+        monkeypatch.setattr(download, "_extract_simple_wiki_bz2", extract_mock)
+        monkeypatch.setattr(download, "_download_file", download_mock)
+
+        # Act
+        download.download_simple_wiki_dump(
+            "https://example.com/simplewiki-latest-pages-articles.xml.bz2"
+        )
+
+        # Assert
+        extract_mock.assert_not_called()
+        download_mock.assert_not_called()
+
+    def test_download_simple_wiki_dump_extracts_when_xml_missing(
+        self, monkeypatch: MonkeyPatch
+    ) -> None:
+        """
+        Verify extraction runs when the XML is missing.
+
+        Purpose:
+            Ensure the download flow extracts when the compressed dump exists
+            but the XML output is absent.
+
+        Args:
+            monkeypatch (MonkeyPatch): Pytest monkeypatch fixture for stubbing
+                filesystem checks and helper functions.
+
+        Returns:
+            None.
+
+        Raises:
+            AssertionError: If download is invoked or extraction is skipped.
+
+        Side Effects:
+            Patches filesystem calls to avoid real disk access.
+        """
+        # Arrange
+        bz2_path = Path(
+            "data/corpus/raw/simple_wiki/simplewiki-latest-pages-articles.xml.bz2"
+        )
+        xml_path = bz2_path.with_suffix(".xml")
+        extract_mock = MagicMock()
+        download_mock = MagicMock()
+
+        def fake_exists(path: Path) -> bool:
+            """
+            Report bz2 exists while XML does not.
+
+            Purpose:
+                Force the extraction branch without triggering download.
+
+            Args:
+                path (Path): Path to check.
+
+            Returns:
+                bool: True for bz2, False for XML and others.
+
+            Raises:
+                None.
+
+            Side Effects:
+                None.
+            """
+            if path == bz2_path:
+                return True
+            if path == xml_path:
+                return False
+            return False
+
+        monkeypatch.setattr(download, "ensure_dirs", lambda: None)
+        monkeypatch.setattr(download, "SIMPLE_WIKI_DIR", bz2_path.parent)
+        monkeypatch.setattr(Path, "exists", fake_exists)
+        monkeypatch.setattr(download, "_extract_simple_wiki_bz2", extract_mock)
+        monkeypatch.setattr(download, "_download_file", download_mock)
+
+        # Act
+        download.download_simple_wiki_dump(
+            "https://example.com/simplewiki-latest-pages-articles.xml.bz2"
+        )
+
+        # Assert
+        extract_mock.assert_called_once_with(bz2_path)
+        download_mock.assert_not_called()
+
+    def test_download_simple_wiki_dump_downloads_then_extracts(
+        self, monkeypatch: MonkeyPatch
+    ) -> None:
+        """
+        Verify download occurs before extraction when bz2 is missing.
+
+        Purpose:
+            Confirm the flow downloads the dump and then invokes extraction
+            when the bz2 file is absent.
+
+        Args:
+            monkeypatch (MonkeyPatch): Pytest monkeypatch fixture for stubbing
+                filesystem checks and helper functions.
+
+        Returns:
+            None.
+
+        Raises:
+            AssertionError: If the call order differs from expectations.
+
+        Side Effects:
+            Records call order without touching the filesystem.
+        """
+        # Arrange
+        bz2_path = Path(
+            "data/corpus/raw/simple_wiki/simplewiki-latest-pages-articles.xml.bz2"
+        )
+        call_order: list[str] = []
+
+        def fake_exists(path: Path) -> bool:
+            """
+            Indicate that no files exist yet.
+
+            Purpose:
+                Force the download branch by reporting missing paths.
+
+            Args:
+                path (Path): Path to check.
+
+            Returns:
+                bool: Always False.
+
+            Raises:
+                None.
+
+            Side Effects:
+                None.
+            """
+            return False
+
+        def fake_download(url: str, dest: Path) -> None:
+            """
+            Record the download call.
+
+            Purpose:
+                Capture the download step ordering.
+
+            Args:
+                url (str): Download URL (unused beyond logging).
+                dest (Path): Destination path (unused beyond logging).
+
+            Returns:
+                None.
+
+            Raises:
+                None.
+
+            Side Effects:
+                Appends "download" to the call order list.
+            """
+            call_order.append("download")
+
+        def fake_extract(path: Path) -> Path:
+            """
+            Record the extract call and return the XML path.
+
+            Purpose:
+                Capture the extraction step ordering.
+
+            Args:
+                path (Path): BZ2 source path for extraction.
+
+            Returns:
+                Path: Derived XML path used by the helper.
+
+            Raises:
+                None.
+
+            Side Effects:
+                Appends "extract" to the call order list.
+            """
+            call_order.append("extract")
+            return path.with_suffix(".xml")
+
+        monkeypatch.setattr(download, "ensure_dirs", lambda: None)
+        monkeypatch.setattr(download, "SIMPLE_WIKI_DIR", bz2_path.parent)
+        monkeypatch.setattr(Path, "exists", fake_exists)
+        monkeypatch.setattr(download, "_download_file", fake_download)
+        monkeypatch.setattr(download, "_extract_simple_wiki_bz2", fake_extract)
+
+        # Act
+        download.download_simple_wiki_dump(
+            "https://example.com/simplewiki-latest-pages-articles.xml.bz2"
+        )
+
+        # Assert
+        assert call_order == ["download", "extract"]
 
 
 class TestDownloadOerSources:


### PR DESCRIPTION
### Motivation
- The Simple Wiki download step left only `*.xml.bz2` on disk which forced manual decompression and broke the documented workflow (REQ-01 / issue #81). 
- Extraction must be idempotent, stream-based, stdlib-only, and leave the `.bz2` archive as a cache artifact (REQ-02..REQ-06). 

### Description
- Implemented `_extract_simple_wiki_bz2(bz2_path: Path) -> Path` using `bz2.open` + `shutil.copyfileobj` to stream-decompress to a `.xml.tmp` and atomically `replace()` to the final `.xml`, with cleanup on error. 
- Updated `download_simple_wiki_dump` to an idempotent flow that (a) skips when a non-empty `.xml` exists, (b) extracts when `.bz2` exists but `.xml` is missing/empty, and (c) downloads then extracts when `.bz2` is missing, and added INFO-level logging including paths and skip reasons. 
- Added focused pytest coverage for the new helper and download flow (success path, cleanup-on-error, idempotent-skip, recovery-extract, and download→extract ordering) using in-memory streams and monkeypatching to avoid filesystem/network side effects. 
- Updated the README and `docs/source-curation-guide.md` to document that the download now produces both `.xml.bz2` and an extracted `.xml`, and showed the extractor usage with the `.xml` (noting the `.bz2` can also be used). 

### Testing
- Regression tests (targeted) were added under `tests/src/lexile_corpus_tuner/lexile_scoring_model/corpus/test_corpus_download.py` and were exercised during development with `poetry run pytest -k "extract_simple_wiki_bz2 or download_simple_wiki_dump"`. 
- Full toolchain and CI-local verification were run in order: `poetry run black .`, `poetry run ruff check`, `poetry run pyright`, and `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing`. 
- All four steps completed successfully in the final pass (format → lint → type-check → test all exited 0 and the test suite passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696da53de52c8323a8a7de8fbde81f4c)