### PR TITLE
Make preflight and phase QC plan-aware for [expect-fail]/[expect-pass] test expectations

### DIFF
--- a/scripts/dev_tools/atomic_executor/cli.py
+++ b/scripts/dev_tools/atomic_executor/cli.py
@@ -42,6 +42,11 @@ from scripts.dev_tools.atomic_executor.plan_parser import (
     PlanTask,
 )
 from scripts.dev_tools.atomic_executor.prompt_builder import PromptBuilder
+from scripts.dev_tools.atomic_executor.pytest_expectations import (
+    ResolvedTestExpectations,
+    parse_pytest_failure_output,
+    resolve_checked_test_expectations,
+)
 from scripts.dev_tools.atomic_executor.qc_runner import QCLoopResult, QCRunner
 
 DEFAULT_PROMPT_TEMPLATE = ".github/prompts/execute-plan-template.md"
@@ -1259,7 +1264,58 @@ class PreflightQCResult:
     failed_step: str | None = None
 
 
-def _run_preflight_qc_with_capture(workspace: Path) -> PreflightQCResult:
+def _resolve_plan_expectations(
+    parser: PlanParser,
+) -> ResolvedTestExpectations | None:
+    """
+    Resolve checked plan expectations for preflight gating.
+
+    Purpose:
+        Determine if the active plan includes checked expectation tasks.
+
+    Args:
+        parser (PlanParser): Plan parser for the current plan file.
+
+    Returns:
+        ResolvedTestExpectations | None: Resolved expectations, or None when empty.
+    """
+    plan = parser.parse()
+    expectations = resolve_checked_test_expectations(plan)
+    if (
+        not expectations.expected_fail_refs
+        and not expectations.expected_pass_refs
+        and not expectations.missing_test_refs
+    ):
+        return None
+    return expectations
+
+
+def _matches_expected_ref(nodeid: str, expected_refs: set[str]) -> bool:
+    """
+    Check whether a failing nodeid matches any expected ref prefix.
+
+    Purpose:
+        Support prefix matching to handle parameterized pytest nodeids.
+
+    Args:
+        nodeid (str): Failing pytest nodeid.
+        expected_refs (set[str]): Expected nodeid prefixes to match against.
+
+    Returns:
+        bool: True when a prefix match is found.
+    """
+    # Scan the expected refs to allow prefix matching for parametrized tests.
+    for expected_ref in expected_refs:
+        if nodeid.startswith(expected_ref):
+            return True
+    return False
+
+
+def _run_preflight_qc_with_capture(
+    workspace: Path,
+    *,
+    expectations: ResolvedTestExpectations | None = None,
+) -> PreflightQCResult:
     """
     Run full QC toolchain and capture combined output.
 
@@ -1283,6 +1339,7 @@ def _run_preflight_qc_with_capture(workspace: Path) -> PreflightQCResult:
                 "poetry",
                 "run",
                 "pytest",
+                "--color=no",
                 "--cov=src/lexile_corpus_tuner",
                 "--cov=scripts/dev_tools",
                 "--cov-report=term-missing",
@@ -1291,9 +1348,56 @@ def _run_preflight_qc_with_capture(workspace: Path) -> PreflightQCResult:
     ]
 
     all_output: list[str] = []
+    expected_refs: set[str] = set()
+
+    if expectations is not None:
+        expected_refs = (
+            expectations.expected_fail_refs | expectations.expected_pass_refs
+        )
+        if expectations.missing_test_refs:
+            missing_refs = ", ".join(expectations.missing_test_refs)
+            message = (
+                "Missing test reference for expectation-tagged tasks: "
+                f"{missing_refs}"
+            )
+            return PreflightQCResult(
+                success=False,
+                output=message,
+                failed_step="pytest-collect",
+            )
 
     for step_name, cmd in steps:
         all_output.append(f"=== {step_name.upper()} ===")
+
+        if step_name == "pytest" and expectations is not None and expected_refs:
+            all_output.append("=== PYTEST COLLECT ===")
+            collect_cmd = [
+                "poetry",
+                "run",
+                "pytest",
+                "--collect-only",
+                "--color=no",
+                *sorted(expected_refs),
+            ]
+            collect_result = subprocess.run(  # noqa: S603 - static analysis can't verify runtime validation
+                collect_cmd,
+                cwd=workspace,
+                capture_output=True,
+                text=True,
+            )
+            collect_output = (collect_result.stdout or "") + (
+                collect_result.stderr or ""
+            )
+            all_output.append(
+                collect_output.strip() if collect_output else "(no output)"
+            )
+            if collect_result.returncode != 0:
+                return PreflightQCResult(
+                    success=False,
+                    output="\n\n".join(all_output),
+                    failed_step="pytest-collect",
+                )
+
         # Commands are static hardcoded constants (poetry run black/ruff/pyright/pytest)
         result = subprocess.run(  # noqa: S603 - static analysis can't verify runtime validation
             cmd,
@@ -1305,10 +1409,53 @@ def _run_preflight_qc_with_capture(workspace: Path) -> PreflightQCResult:
         all_output.append(combined.strip() if combined else "(no output)")
 
         if result.returncode != 0:
-            return PreflightQCResult(
-                success=False,
-                output="\n\n".join(all_output),
-                failed_step=step_name,
+            if step_name != "pytest" or expectations is None:
+                return PreflightQCResult(
+                    success=False,
+                    output="\n\n".join(all_output),
+                    failed_step=step_name,
+                )
+
+            summary = parse_pytest_failure_output(combined)
+            if summary.has_collection_error:
+                all_output.append(
+                    "Pytest collection/import errors detected; failing QC."
+                )
+                return PreflightQCResult(
+                    success=False,
+                    output="\n\n".join(all_output),
+                    failed_step=step_name,
+                )
+
+            unexpected_failures: list[str] = []
+            expected_pass_hits: list[str] = []
+
+            # Compare failing nodeids against expected refs with prefix matching.
+            for nodeid in summary.failed_nodeids:
+                if _matches_expected_ref(nodeid, expectations.expected_pass_refs):
+                    expected_pass_hits.append(nodeid)
+                    unexpected_failures.append(nodeid)
+                elif _matches_expected_ref(nodeid, expectations.expected_fail_refs):
+                    continue
+                else:
+                    unexpected_failures.append(nodeid)
+
+            if unexpected_failures:
+                all_output.append("Unexpected pytest failures detected.")
+                if expected_pass_hits:
+                    all_output.append(
+                        "Expected-pass override applied to: "
+                        + ", ".join(expected_pass_hits)
+                    )
+                return PreflightQCResult(
+                    success=False,
+                    output="\n\n".join(all_output),
+                    failed_step=step_name,
+                )
+
+            all_output.append(
+                "Expected pytest failures allowed: "
+                + ", ".join(sorted(summary.failed_nodeids))
             )
 
     return PreflightQCResult(
@@ -1374,6 +1521,7 @@ def _run_preflight_qc_fix_loop(
     copilot_allow_all_urls: bool,
     copilot_trust_workspace: bool,
     max_fix_attempts: int,
+    expectations: ResolvedTestExpectations | None,
 ) -> int:
     """
     Run the pre-flight QC fix loop until baseline passes or attempts exhausted.
@@ -1406,6 +1554,7 @@ def _run_preflight_qc_fix_loop(
         copilot_allow_all_urls: Allow all URLs without approval.
         copilot_trust_workspace: Add workspace to trusted folders.
         max_fix_attempts: Max number of fix attempts (0 = infinite).
+        expectations: Optional resolved plan expectations for pytest gating.
 
     Returns:
         int: 0 on success, 6 on failure.
@@ -1424,7 +1573,9 @@ def _run_preflight_qc_fix_loop(
         print("Running pre-flight QC check...")
         _log_msg(log_file, "INFO: Running pre-flight QC check")
 
-        preflight_check = _run_preflight_qc_with_capture(workspace)
+        preflight_check = _run_preflight_qc_with_capture(
+            workspace, expectations=expectations
+        )
         if preflight_check.success:
             # QC passed - we're done
             print("Pre-flight QC passed.")
@@ -2101,6 +2252,7 @@ def main(argv: list[str] | None = None) -> int:
             preferred_model=args.preferred_model,
         )
         qc_runner = QCRunner(workspace)
+        preflight_expectations = _resolve_plan_expectations(parser)
 
         # Per-run throttling controls. The limiter must persist across tasks to
         # regulate overall call cadence.
@@ -2134,6 +2286,7 @@ def main(argv: list[str] | None = None) -> int:
                 copilot_allow_all_urls=args.copilot_allow_all_urls,
                 copilot_trust_workspace=args.copilot_trust_workspace,
                 max_fix_attempts=args.max_fix_attempts,
+                expectations=preflight_expectations,
             )
             if preflight_result != 0:
                 return preflight_result
@@ -2202,7 +2355,8 @@ def main(argv: list[str] | None = None) -> int:
                 else:
                     print(f"Phase {cur.phase} complete -> running full toolchain...")
                     try:
-                        qc_runner.run_full()
+                        phase_expectations = _resolve_plan_expectations(parser)
+                        qc_runner.run_full(expectations=phase_expectations)
                     except subprocess.CalledProcessError as e:
                         print(
                             f"Full QC failed after completing Phase {cur.phase}: {e}",

--- a/scripts/dev_tools/atomic_executor/plan_parser.py
+++ b/scripts/dev_tools/atomic_executor/plan_parser.py
@@ -21,6 +21,12 @@ TASK_LINE_RE = re.compile(
 )
 
 PHASE_HEADING_RE = re.compile(r"^\s*#+\s*Phase\s+(?P<phase>\d+)\b", re.IGNORECASE)
+EXPECT_FAIL_TAG = "[expect-fail]"
+EXPECT_SUCCESS_TAG = "[expect-pass]"
+PYTEST_REF_PREFIX = "pytest "
+PROSE_PYTEST_REF_RE = re.compile(
+    r"^Add pytest `(?P<test_name>[^`]+)` in `(?P<path>[^`]+)`$"
+)
 
 QC_STEP_PATTERNS: dict[str, re.Pattern[str]] = {
     "black": re.compile(r"poetry\s+run\s+black\b", re.IGNORECASE),
@@ -50,6 +56,10 @@ class PlanTask:
         line_index (int): Zero-based line number in plan.md (for editing).
         expect_fail (bool): True if task title was annotated with [expect-fail]
             tag (inverts pytest success criteria for TDD Red workflow).
+        expect_pass (bool): True if task title was annotated with [expect-pass]
+            tag (declares pytest failures unacceptable for the referenced test).
+        test_ref (str | None): Optional pytest nodeid or nodeid prefix extracted
+            from the task title when expectation tags are present.
     """
 
     task_id: str
@@ -59,6 +69,35 @@ class PlanTask:
     checked: bool
     line_index: int
     expect_fail: bool = False
+    expect_pass: bool = False
+    test_ref: str | None = None
+
+
+def _extract_test_ref(title: str) -> str | None:
+    """
+    Extract a pytest nodeid reference from a plan task title.
+
+    Purpose:
+        Convert expectation-tagged task titles into deterministic pytest refs.
+
+    Args:
+        title (str): Task title after stripping expectation tags.
+
+    Returns:
+        str | None: Extracted nodeid/prefix or None when absent.
+    """
+    normalized_title = title.strip()
+
+    # Prefer explicit pytest references to avoid ambiguous inference.
+    if normalized_title.lower().startswith(PYTEST_REF_PREFIX):
+        return normalized_title[len(PYTEST_REF_PREFIX) :].strip()
+
+    # Fall back to the prose form used in plan templates.
+    prose_match = PROSE_PYTEST_REF_RE.match(normalized_title)
+    if prose_match:
+        return f"{prose_match.group('path')}::{prose_match.group('test_name')}"
+
+    return None
 
 
 @dataclass(frozen=True)
@@ -172,12 +211,22 @@ class PlanParser:
                 checked = m.group("state").strip().lower() == "x"
                 raw_title = m.group("title").strip()
 
-                # Detect [expect-fail] tag at the start of the title (TDD Red workflow).
-                # If present, set expect_fail=True and remove the tag from the title.
+                # Decide which expectation tag applies so downstream QC can
+                # interpret it.
                 expect_fail = False
-                if raw_title.lower().startswith("[expect-fail]"):
+                expect_pass = False
+                if raw_title.lower().startswith(EXPECT_FAIL_TAG):
                     expect_fail = True
-                    raw_title = raw_title[len("[expect-fail]") :].strip()
+                    raw_title = raw_title[len(EXPECT_FAIL_TAG) :].strip()
+                elif raw_title.lower().startswith(EXPECT_SUCCESS_TAG):
+                    expect_pass = True
+                    raw_title = raw_title[len(EXPECT_SUCCESS_TAG) :].strip()
+
+                # Capture an explicit pytest reference when expectation tags
+                # are present.
+                test_ref = None
+                if expect_fail or expect_pass:
+                    test_ref = _extract_test_ref(raw_title)
 
                 tasks.append(
                     PlanTask(
@@ -188,6 +237,8 @@ class PlanParser:
                         checked=checked,
                         line_index=idx,
                         expect_fail=expect_fail,
+                        expect_pass=expect_pass,
+                        test_ref=test_ref,
                     )
                 )
                 phases.add(phase)

--- a/scripts/dev_tools/atomic_executor/pytest_expectations.py
+++ b/scripts/dev_tools/atomic_executor/pytest_expectations.py
@@ -1,0 +1,139 @@
+"""
+Expectation resolution and pytest failure parsing helpers for atomic executor.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from scripts.dev_tools.atomic_executor.plan_parser import PlanModel
+
+FAILED_NODEID_RE = re.compile(r"^FAILED\s+(?P<nodeid>\S+)")
+COLLECTION_ERROR_RE = re.compile(r"^ERROR\s+collecting\s+", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class ResolvedTestExpectations:
+    """
+    Resolved expectations for pytest outcomes derived from a plan.
+
+    Purpose:
+        Provide normalized expectation sets for QC gating decisions.
+
+    Attributes:
+        expected_fail_refs (set[str]): Test refs allowed to fail.
+        expected_pass_refs (set[str]): Test refs required to pass.
+        missing_test_refs (list[str]): Checked expectation task IDs lacking test refs.
+    """
+
+    expected_fail_refs: set[str]
+    expected_pass_refs: set[str]
+    missing_test_refs: list[str]
+
+
+@dataclass(frozen=True)
+class PytestFailureSummary:
+    """
+    Parsed summary of pytest failures from captured output.
+
+    Purpose:
+        Normalize pytest output into data used for QC gate decisions.
+
+    Attributes:
+        failed_nodeids (set[str]): Nodeids reported as failed.
+        has_collection_error (bool): True when collection/import errors appear.
+    """
+
+    failed_nodeids: set[str]
+    has_collection_error: bool
+
+
+def resolve_checked_test_expectations(plan: PlanModel) -> ResolvedTestExpectations:
+    """
+    Resolve expectation tags from checked plan tasks.
+
+    Purpose:
+        Collect expected-fail and expected-pass refs derived from checked tasks.
+
+    Args:
+        plan (PlanModel): Parsed plan model to inspect.
+
+    Returns:
+        ResolvedTestExpectations: Normalized expectation sets and missing refs.
+
+    """
+    expected_fail_refs: set[str] = set()
+    expected_pass_refs: set[str] = set()
+    missing_test_refs: list[str] = []
+
+    # Walk checked tasks with expectation tags and gather their test references.
+    for task in plan.tasks:
+        if not task.checked:
+            continue
+        if not (task.expect_fail or task.expect_pass):
+            continue
+        if not task.test_ref:
+            missing_test_refs.append(task.task_id)
+            continue
+        if task.expect_pass:
+            expected_pass_refs.add(task.test_ref)
+        elif task.expect_fail:
+            expected_fail_refs.add(task.test_ref)
+
+    # Enforce override semantics so expected-pass wins for the same ref.
+    expected_fail_refs.difference_update(expected_pass_refs)
+
+    return ResolvedTestExpectations(
+        expected_fail_refs=expected_fail_refs,
+        expected_pass_refs=expected_pass_refs,
+        missing_test_refs=missing_test_refs,
+    )
+
+
+def parse_pytest_failure_output(output: str) -> PytestFailureSummary:
+    """
+    Parse pytest output into failing nodeids and collection status.
+
+    Purpose:
+        Identify failing tests and collection/import errors from pytest output.
+
+    Args:
+        output (str): Combined stdout/stderr captured from pytest.
+
+    Returns:
+        PytestFailureSummary: Parsed nodeids and collection error flag.
+
+    """
+    failed_nodeids: set[str] = set()
+    has_collection_error = False
+
+    lines = output.splitlines()
+
+    # Scan pytest output line-by-line to extract failures and error conditions.
+    for line in lines:
+        stripped = line.strip()
+        failed_match = FAILED_NODEID_RE.match(stripped)
+        if failed_match:
+            failed_nodeids.add(failed_match.group("nodeid"))
+            continue
+
+        # Flag collection/import errors so QC gates can fail fast.
+        if COLLECTION_ERROR_RE.match(stripped):
+            has_collection_error = True
+            continue
+        if stripped.lower().startswith("importerror while importing test module"):
+            has_collection_error = True
+            continue
+        if stripped.lower().startswith("error during collection"):
+            has_collection_error = True
+            continue
+        if stripped.lower().startswith("error "):
+            has_collection_error = True
+
+    return PytestFailureSummary(
+        failed_nodeids=failed_nodeids,
+        has_collection_error=has_collection_error,
+    )

--- a/scripts/dev_tools/atomic_executor/qc_runner.py
+++ b/scripts/dev_tools/atomic_executor/qc_runner.py
@@ -12,6 +12,11 @@ import subprocess
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from scripts.dev_tools.atomic_executor.pytest_expectations import (
+    ResolvedTestExpectations,
+    parse_pytest_failure_output,
+)
+
 if TYPE_CHECKING:
     from collections.abc import Iterable
     from pathlib import Path
@@ -57,6 +62,7 @@ class QCRunner:
         "poetry",
         "run",
         "pytest",
+        "--color=no",
         "--cov=src/lexile_corpus_tuner",
         "--cov-report=xml",
         "--cov-report=term-missing",
@@ -108,12 +114,16 @@ class QCRunner:
                 env=self._merge_env(self._lock_bypass_env()),
             )
 
-    def run_full(self) -> None:
+    def run_full(self, *, expectations: ResolvedTestExpectations | None = None) -> None:
         """
         Run full toolchain on entire codebase (phase gate).
 
         Purpose:
             Comprehensive QC verification after a phase completes.
+
+        Args:
+            expectations (ResolvedTestExpectations | None): Optional expected
+                pytest failures derived from the active plan.
 
         Raises:
             CalledProcessError: If any QC command fails.
@@ -124,10 +134,73 @@ class QCRunner:
         self._run(self.FULL_FMT)
         self._run(self.FULL_LINT)
         self._run(self.FULL_TYPE)
-        self._run(
+        self._run_pytest_with_expectations(expectations)
+
+    def _run_pytest_with_expectations(
+        self,
+        expectations: ResolvedTestExpectations | None,
+    ) -> None:
+        """
+        Run pytest and apply expectation filtering to failures.
+
+        Purpose:
+            Allow expected-fail tests to fail while still failing on unexpected
+            errors or expected-pass overrides.
+
+        Args:
+            expectations (ResolvedTestExpectations | None): Optional expected
+                pytest failures derived from the active plan.
+
+        Raises:
+            CalledProcessError: If pytest fails unexpectedly.
+        """
+        env = self._merge_env(self._lock_bypass_env())
+        if expectations is None:
+            self._run(self.FULL_TEST, env=env)
+            return
+
+        if expectations.missing_test_refs:
+            missing_refs = ", ".join(expectations.missing_test_refs)
+            raise RuntimeError(
+                "Missing test reference for expectation-tagged tasks: "
+                f"{missing_refs}"
+            )
+
+        result = subprocess.run(  # noqa: S603 - argv constructed from trusted constants
             self.FULL_TEST,
-            env=self._merge_env(self._lock_bypass_env()),
+            cwd=self.workspace,
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
         )
+        combined = (result.stdout or "") + (result.stderr or "")
+        if result.returncode == 0:
+            return
+
+        summary = parse_pytest_failure_output(combined)
+        if summary.has_collection_error:
+            raise subprocess.CalledProcessError(
+                result.returncode, self.FULL_TEST, output=combined
+            )
+
+        unexpected_failures: list[str] = []
+        expected_pass_hits: list[str] = []
+
+        # Compare failing nodeids against expected refs with prefix matching.
+        for nodeid in summary.failed_nodeids:
+            if _matches_expected_ref(nodeid, expectations.expected_pass_refs):
+                expected_pass_hits.append(nodeid)
+                unexpected_failures.append(nodeid)
+            elif _matches_expected_ref(nodeid, expectations.expected_fail_refs):
+                continue
+            else:
+                unexpected_failures.append(nodeid)
+
+        if unexpected_failures or expected_pass_hits:
+            raise subprocess.CalledProcessError(
+                result.returncode, self.FULL_TEST, output=combined
+            )
 
     def run_full_loop_with_artifacts(
         self,
@@ -552,3 +625,24 @@ class QCLoopResult:
     success: bool
     failure: QCLoopFailure | None
     loop_count: int
+
+
+def _matches_expected_ref(nodeid: str, expected_refs: set[str]) -> bool:
+    """
+    Check whether a failing nodeid matches any expected ref prefix.
+
+    Purpose:
+        Support prefix matching to handle parameterized pytest nodeids.
+
+    Args:
+        nodeid (str): Failing pytest nodeid.
+        expected_refs (set[str]): Expected nodeid prefixes to match against.
+
+    Returns:
+        bool: True when a prefix match is found.
+    """
+    # Scan the expected refs to allow prefix matching for parametrized tests.
+    for expected_ref in expected_refs:
+        if nodeid.startswith(expected_ref):
+            return True
+    return False

--- a/tests/fixtures/atomic_executor/plan_expect_fail_with_prose_ref.md
+++ b/tests/fixtures/atomic_executor/plan_expect_fail_with_prose_ref.md
@@ -1,0 +1,3 @@
+## Phase 1
+
+- [x] [P1-T1] [expect-fail] Add pytest `test_expected_fail` in `tests/bugs/2026/test_issue_98.py`

--- a/tests/fixtures/atomic_executor/plan_expect_fail_with_pytest_ref.md
+++ b/tests/fixtures/atomic_executor/plan_expect_fail_with_pytest_ref.md
@@ -1,0 +1,3 @@
+## Phase 1
+
+- [x] [P1-T1] [expect-fail] pytest tests/bugs/2026/test_issue_98.py::test_expected_fail

--- a/tests/fixtures/atomic_executor/plan_expect_pass.md
+++ b/tests/fixtures/atomic_executor/plan_expect_pass.md
@@ -1,0 +1,3 @@
+## Phase 1
+
+- [ ] [P1-T1] [expect-pass] pytest tests/bugs/2026/test_issue_98.py::test_expected_pass

--- a/tests/scripts/dev_tools/atomic_executor/test_cli.py
+++ b/tests/scripts/dev_tools/atomic_executor/test_cli.py
@@ -1040,6 +1040,212 @@ class TestPreflightQC:
         assert args.skip_preflight_qc is False
 
 
+class TestPhaseEndQC:
+    """Tests for phase-end QC behavior in the CLI."""
+
+    def test_phase_end_expectations_passed_to_qc_runner(
+        self, monkeypatch: "MonkeyPatch"
+    ) -> None:
+        """
+        CLI should pass resolved expectations to phase-end QC.
+
+        Purpose:
+            Ensure phase completion forwards plan expectations into run_full().
+        """
+        from scripts.dev_tools.atomic_executor import cli
+        from scripts.dev_tools.atomic_executor.plan_parser import PlanModel, PlanTask
+
+        plan_task = PlanTask(
+            task_id="P1-T1",
+            phase=1,
+            task_num=1,
+            title="pytest tests/bugs/2026/test_issue_98.py::test_expected_fail",
+            checked=True,
+            line_index=0,
+            expect_fail=True,
+            test_ref="tests/bugs/2026/test_issue_98.py::test_expected_fail",
+        )
+        plan = PlanModel(tasks=[plan_task], phases=[1])
+
+        parser = Mock()
+        parser.next_unchecked_task.return_value = plan_task
+        parser.find_task_by_id.return_value = plan_task
+        parser.phase_complete.return_value = True
+        parser.preflight_validate.return_value = None
+        parser.parse.return_value = plan
+
+        resolver = Mock()
+        resolver.resolve.return_value = (Mock(), Path.cwd())
+        qc_runner = Mock()
+
+        monkeypatch.setattr(cli, "PlanParser", lambda _path: parser)
+        monkeypatch.setattr(cli, "FeatureResolver", Mock(return_value=resolver))
+        monkeypatch.setattr(cli, "QCRunner", Mock(return_value=qc_runner))
+        monkeypatch.setattr(cli, "resolve_workspace", lambda _workspace: Path.cwd())
+        monkeypatch.setattr(
+            cli,
+            "resolve_feature_plan",
+            lambda _dir: Mock(path=Path("docs/features/active/README.md")),
+        )
+        monkeypatch.setattr(cli, "refuse_protected_branch", lambda _workspace: None)
+        monkeypatch.setattr(cli, "execute_one_task", lambda **_kwargs: 0)
+
+        exit_code = cli.main(["execute", "feature", "--skip-preflight-qc"])
+
+        assert exit_code == 0
+        qc_runner.run_full.assert_called_once()
+        _, kwargs = qc_runner.run_full.call_args
+        assert "expectations" in kwargs
+        assert (
+            "tests/bugs/2026/test_issue_98.py::test_expected_fail"
+            in kwargs["expectations"].expected_fail_refs
+        )
+
+    def test_preflight_expected_fail_allows_known_failures(
+        self,
+        monkeypatch: "MonkeyPatch",
+    ) -> None:
+        """
+        Preflight QC should allow failures covered by expected-fail refs.
+
+        Purpose:
+            Ensure expected-fail refs suppress baseline fix behavior for pytest.
+        """
+        from scripts.dev_tools.atomic_executor.cli import (
+            _run_preflight_qc_with_capture,
+        )
+        from scripts.dev_tools.atomic_executor.pytest_expectations import (
+            ResolvedTestExpectations,
+        )
+
+        expectations = ResolvedTestExpectations(
+            expected_fail_refs={"tests/bugs/2026/test_issue_98.py::test_expected_fail"},
+            expected_pass_refs=set(),
+            missing_test_refs=[],
+        )
+
+        def mock_run(
+            *args: object, **kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            """Return a failing pytest run for the expected-fail nodeid."""
+            cmd = args[0]
+            if isinstance(cmd, list) and "pytest" in cmd and "--collect-only" in cmd:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout="collected", stderr=""
+                )
+            if isinstance(cmd, list) and "pytest" in cmd:
+                output = (
+                    "FAILED tests/bugs/2026/test_issue_98.py::"
+                    "test_expected_fail - AssertionError"
+                )
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=1, stdout=output, stderr=""
+                )
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="OK", stderr=""
+            )
+
+        monkeypatch.setattr("subprocess.run", mock_run)
+
+        result = _run_preflight_qc_with_capture(Path.cwd(), expectations=expectations)
+
+        assert result.success is True
+        assert result.failed_step is None
+        assert "expected pytest failures" in result.output.lower()
+
+    def test_preflight_expected_pass_wins(
+        self,
+        monkeypatch: "MonkeyPatch",
+    ) -> None:
+        """
+        Expected-pass should override expected-fail for the same ref.
+
+        Purpose:
+            Ensure expected-pass entries cause the pytest gate to fail.
+        """
+        from scripts.dev_tools.atomic_executor.cli import (
+            _run_preflight_qc_with_capture,
+        )
+        from scripts.dev_tools.atomic_executor.pytest_expectations import (
+            ResolvedTestExpectations,
+        )
+
+        expectations = ResolvedTestExpectations(
+            expected_fail_refs={"tests/bugs/2026/test_issue_98.py::test_expected_fail"},
+            expected_pass_refs={"tests/bugs/2026/test_issue_98.py::test_expected_fail"},
+            missing_test_refs=[],
+        )
+
+        def mock_run(
+            *args: object, **kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            """Return a failing pytest run for the expected-pass nodeid."""
+            cmd = args[0]
+            if isinstance(cmd, list) and "pytest" in cmd and "--collect-only" in cmd:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout="collected", stderr=""
+                )
+            if isinstance(cmd, list) and "pytest" in cmd:
+                output = (
+                    "FAILED tests/bugs/2026/test_issue_98.py::"
+                    "test_expected_fail - AssertionError"
+                )
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=1, stdout=output, stderr=""
+                )
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="OK", stderr=""
+            )
+
+        monkeypatch.setattr("subprocess.run", mock_run)
+
+        result = _run_preflight_qc_with_capture(Path.cwd(), expectations=expectations)
+
+        assert result.success is False
+        assert result.failed_step == "pytest"
+        assert "expected-pass" in result.output.lower()
+
+    def test_preflight_missing_test_ref(
+        self,
+        monkeypatch: "MonkeyPatch",
+    ) -> None:
+        """
+        Missing test refs should fail preflight before running pytest.
+
+        Purpose:
+            Provide actionable feedback when expectation tasks lack test refs.
+        """
+        from scripts.dev_tools.atomic_executor.cli import (
+            _run_preflight_qc_with_capture,
+        )
+        from scripts.dev_tools.atomic_executor.pytest_expectations import (
+            ResolvedTestExpectations,
+        )
+
+        expectations = ResolvedTestExpectations(
+            expected_fail_refs=set(),
+            expected_pass_refs=set(),
+            missing_test_refs=["P1-T1"],
+        )
+
+        def mock_run(
+            *args: object, **kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            """Return success for non-pytest steps."""
+            cmd = args[0]
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="OK", stderr=""
+            )
+
+        monkeypatch.setattr("subprocess.run", mock_run)
+
+        result = _run_preflight_qc_with_capture(Path.cwd(), expectations=expectations)
+
+        assert result.success is False
+        assert result.failed_step == "pytest-collect"
+        assert "missing test reference" in result.output.lower()
+
+
 class TestRunCopilot:
     """Tests for run_copilot() function."""
 

--- a/tests/scripts/dev_tools/atomic_executor/test_plan_parser.py
+++ b/tests/scripts/dev_tools/atomic_executor/test_plan_parser.py
@@ -28,6 +28,9 @@ class TestPlanTask:
             title="Example task",
             checked=True,
             line_index=10,
+            expect_fail=False,
+            expect_pass=True,
+            test_ref="tests/sample.py::test_example",
         )
         assert task.task_id == "P1-T2"
         assert task.phase == 1
@@ -35,6 +38,9 @@ class TestPlanTask:
         assert task.title == "Example task"
         assert task.checked is True
         assert task.line_index == 10
+        assert task.expect_fail is False
+        assert task.expect_pass is True
+        assert task.test_ref == "tests/sample.py::test_example"
 
     def test_plan_task_immutability_frozen(self) -> None:
         """PlanTask is frozen and cannot be modified after creation."""
@@ -127,6 +133,66 @@ class TestPlanParserParse:
 
         assert model.tasks[0].expect_fail is True
         assert model.tasks[0].title == "Add failing regression test"
+
+    def test_parse_sets_expect_pass_true_and_strips_tag(self) -> None:
+        """
+        PlanParser.parse should detect and strip the [expect-pass] tag.
+
+        Purpose:
+            Ensure expect-pass tasks are recognized and stored as plan metadata.
+
+        Side Effects:
+            Reads a committed fixture file from tests/fixtures (no temp files).
+        """
+        parser = PlanParser(Path("tests/fixtures/atomic_executor/plan_expect_pass.md"))
+        model = parser.parse()
+
+        assert model.tasks[0].expect_pass is True
+        assert model.tasks[0].expect_fail is False
+        assert (
+            model.tasks[0].title
+            == "pytest tests/bugs/2026/test_issue_98.py::test_expected_pass"
+        )
+
+    def test_parse_extracts_test_ref_from_pytest_form(self) -> None:
+        """
+        PlanParser.parse should extract a test_ref from the pytest form.
+
+        Purpose:
+            Validate that "pytest <nodeid>" forms are parsed into test_ref.
+
+        Side Effects:
+            Reads a committed fixture file from tests/fixtures (no temp files).
+        """
+        parser = PlanParser(
+            Path("tests/fixtures/atomic_executor/plan_expect_fail_with_pytest_ref.md")
+        )
+        model = parser.parse()
+
+        assert (
+            model.tasks[0].test_ref
+            == "tests/bugs/2026/test_issue_98.py::test_expected_fail"
+        )
+
+    def test_parse_extracts_test_ref_from_prose_ref_form(self) -> None:
+        """
+        PlanParser.parse should extract a test_ref from the prose form.
+
+        Purpose:
+            Ensure "Add pytest `name` in `path`" yields a stable nodeid prefix.
+
+        Side Effects:
+            Reads a committed fixture file from tests/fixtures (no temp files).
+        """
+        parser = PlanParser(
+            Path("tests/fixtures/atomic_executor/plan_expect_fail_with_prose_ref.md")
+        )
+        model = parser.parse()
+
+        assert (
+            model.tasks[0].test_ref
+            == "tests/bugs/2026/test_issue_98.py::test_expected_fail"
+        )
 
     def test_parse_defaults_expect_fail_false_when_tag_missing(
         self, tmp_path: Path

--- a/tests/scripts/dev_tools/atomic_executor/test_pytest_expectations.py
+++ b/tests/scripts/dev_tools/atomic_executor/test_pytest_expectations.py
@@ -1,0 +1,173 @@
+"""
+Tests for pytest expectation resolution and failure parsing helpers.
+"""
+
+from scripts.dev_tools.atomic_executor.plan_parser import PlanModel, PlanTask
+from scripts.dev_tools.atomic_executor.pytest_expectations import (
+    parse_pytest_failure_output,
+    resolve_checked_test_expectations,
+)
+
+
+class TestResolveCheckedTestExpectations:
+    """Tests for resolve_checked_test_expectations."""
+
+    def test_expect_pass_overrides_expect_fail(self) -> None:
+        """
+        Expected-pass overrides expected-fail for the same test ref.
+
+        Purpose:
+            Ensure the override rule keeps a ref in expected-pass only.
+        """
+        test_ref = "tests/bugs/2026/test_issue_98.py::test_expected_fail"
+        plan = PlanModel(
+            tasks=[
+                PlanTask(
+                    "P1-T1",
+                    1,
+                    1,
+                    "pytest tests/bugs/2026/test_issue_98.py::test_expected_fail",
+                    True,
+                    0,
+                    expect_fail=True,
+                    test_ref=test_ref,
+                ),
+                PlanTask(
+                    "P1-T2",
+                    1,
+                    2,
+                    "pytest tests/bugs/2026/test_issue_98.py::test_expected_fail",
+                    True,
+                    1,
+                    expect_pass=True,
+                    test_ref=test_ref,
+                ),
+            ],
+            phases=[1],
+        )
+
+        expectations = resolve_checked_test_expectations(plan)
+
+        assert expectations.expected_fail_refs == set()
+        assert expectations.expected_pass_refs == {test_ref}
+        assert expectations.missing_test_refs == []
+
+    def test_only_checked_tasks_contribute_expectations(self) -> None:
+        """
+        Unchecked tasks should not contribute to expectation sets.
+
+        Purpose:
+            Guard against uncompleted work affecting QC behavior.
+        """
+        plan = PlanModel(
+            tasks=[
+                PlanTask(
+                    "P1-T1",
+                    1,
+                    1,
+                    "pytest tests/bugs/2026/test_issue_98.py::test_expected_fail",
+                    False,
+                    0,
+                    expect_fail=True,
+                    test_ref="tests/bugs/2026/test_issue_98.py::test_expected_fail",
+                ),
+                PlanTask(
+                    "P1-T2",
+                    1,
+                    2,
+                    "pytest tests/bugs/2026/test_issue_98.py::test_expected_pass",
+                    True,
+                    1,
+                    expect_pass=True,
+                    test_ref="tests/bugs/2026/test_issue_98.py::test_expected_pass",
+                ),
+            ],
+            phases=[1],
+        )
+
+        expectations = resolve_checked_test_expectations(plan)
+
+        assert expectations.expected_fail_refs == set()
+        assert expectations.expected_pass_refs == {
+            "tests/bugs/2026/test_issue_98.py::test_expected_pass"
+        }
+        assert expectations.missing_test_refs == []
+
+
+class TestParsePytestFailureOutput:
+    """Tests for parse_pytest_failure_output."""
+
+    def test_parses_failing_nodeids(self) -> None:
+        """
+        Pytest failing nodeids should be extracted from summary output.
+
+        Purpose:
+            Ensure parameterized nodeids are captured verbatim.
+        """
+        output = "\n".join(
+            [
+                (
+                    "========================= short test summary info "
+                    "========================="
+                ),
+                (
+                    "FAILED tests/bugs/2026/test_issue_98.py::"
+                    "test_preflight_respects_expectations - AssertionError"
+                ),
+                (
+                    "FAILED tests/bugs/2026/test_issue_98.py::"
+                    "test_preflight_respects_expectations[param0] - AssertionError"
+                ),
+                (
+                    "FAILED tests/other/test_other.py::test_unrelated "
+                    "- AssertionError"
+                ),
+                (
+                    "====================== 3 failed, 10 passed in 0.21s "
+                    "======================"
+                ),
+            ]
+        )
+        summary = parse_pytest_failure_output(output)
+
+        assert summary.failed_nodeids == {
+            "tests/bugs/2026/test_issue_98.py::test_preflight_respects_expectations",
+            "tests/bugs/2026/test_issue_98.py::test_preflight_respects_expectations[param0]",
+            "tests/other/test_other.py::test_unrelated",
+        }
+        assert summary.has_collection_error is False
+
+    def test_detects_collection_errors(self) -> None:
+        """
+        Collection/import errors should be treated as gate failures.
+
+        Purpose:
+            Ensure collection errors are flagged separately from test failures.
+        """
+        output = "\n".join(
+            [
+                (
+                    "============================= test session starts "
+                    "============================="
+                ),
+                "ERROR collecting tests/bugs/2026/test_issue_98.py",
+                (
+                    "ImportError while importing test module "
+                    "'/workspaces/.../tests/bugs/2026/test_issue_98.py'."
+                ),
+                "E   ModuleNotFoundError: No module named 'some_missing_dep'",
+                (
+                    "=========================== short test summary info "
+                    "============================"
+                ),
+                "ERROR tests/bugs/2026/test_issue_98.py",
+                (
+                    "!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection "
+                    "!!!!!!!!!!!!!!!!!!!!"
+                ),
+            ]
+        )
+        summary = parse_pytest_failure_output(output)
+
+        assert summary.failed_nodeids == set()
+        assert summary.has_collection_error is True

--- a/tests/scripts/dev_tools/atomic_executor/test_qc_runner.py
+++ b/tests/scripts/dev_tools/atomic_executor/test_qc_runner.py
@@ -412,6 +412,7 @@ class TestQCRunnerRunFull:
             "poetry",
             "run",
             "pytest",
+            "--color=no",
             "--cov=src/lexile_corpus_tuner",
             "--cov-report=xml",
             "--cov-report=term-missing",
@@ -439,6 +440,89 @@ class TestQCRunnerRunFull:
         runner = QCRunner(tmp_path)
         with pytest.raises(subprocess.CalledProcessError):
             runner.run_full()
+
+    def test_phase_expected_fail_tolerates_pytest_failures(
+        self, tmp_path: Path, monkeypatch: "MonkeyPatch"
+    ) -> None:
+        """
+        run_full() tolerates expected pytest failures when expectations exist.
+
+        Purpose:
+            Ensure expected-fail refs do not fail the phase gate.
+        """
+        from scripts.dev_tools.atomic_executor.pytest_expectations import (
+            ResolvedTestExpectations,
+        )
+
+        expectations = ResolvedTestExpectations(
+            expected_fail_refs={"tests/bugs/2026/test_issue_98.py::test_expected_fail"},
+            expected_pass_refs=set(),
+            missing_test_refs=[],
+        )
+
+        def mock_run(
+            argv: list[str], *args: object, **kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            if "pytest" in argv:
+                return subprocess.CompletedProcess(
+                    args=argv,
+                    returncode=1,
+                    stdout=(
+                        "FAILED tests/bugs/2026/test_issue_98.py::"
+                        "test_expected_fail - AssertionError"
+                    ),
+                    stderr="",
+                )
+            return subprocess.CompletedProcess(
+                args=argv, returncode=0, stdout="", stderr=""
+            )
+
+        monkeypatch.setattr("subprocess.run", mock_run)
+
+        runner = QCRunner(tmp_path)
+        runner.run_full(expectations=expectations)
+
+    def test_phase_unexpected_fail_raises_on_pytest_failures(
+        self, tmp_path: Path, monkeypatch: "MonkeyPatch"
+    ) -> None:
+        """
+        run_full() raises when pytest failures are unexpected.
+
+        Purpose:
+            Confirm unexpected pytest failures continue to fail the phase gate.
+        """
+        from scripts.dev_tools.atomic_executor.pytest_expectations import (
+            ResolvedTestExpectations,
+        )
+
+        expectations = ResolvedTestExpectations(
+            expected_fail_refs=set(),
+            expected_pass_refs=set(),
+            missing_test_refs=[],
+        )
+
+        def mock_run(
+            argv: list[str], *args: object, **kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            if "pytest" in argv:
+                return subprocess.CompletedProcess(
+                    args=argv,
+                    returncode=1,
+                    stdout=(
+                        "FAILED tests/bugs/2026/test_issue_98.py::"
+                        "test_unexpected - AssertionError"
+                    ),
+                    stderr="",
+                )
+            return subprocess.CompletedProcess(
+                args=argv, returncode=0, stdout="", stderr=""
+            )
+
+        monkeypatch.setattr("subprocess.run", mock_run)
+
+        runner = QCRunner(tmp_path)
+        with pytest.raises(subprocess.CalledProcessError):
+            runner.run_full(expectations=expectations)
 
 
 class TestQCRunnerEdgeCases:

--- a/tests/scripts/dev_tools/test_atomic_executor_cli.py
+++ b/tests/scripts/dev_tools/test_atomic_executor_cli.py
@@ -21,7 +21,7 @@ import pytest
 from scripts.dev_tools.atomic_executor import cli
 from scripts.dev_tools.atomic_executor.cli import main
 from scripts.dev_tools.atomic_executor.copilot_runner import CopilotRunResult
-from scripts.dev_tools.atomic_executor.plan_parser import PlanTask
+from scripts.dev_tools.atomic_executor.plan_parser import PlanModel, PlanTask
 
 
 @pytest.fixture
@@ -59,6 +59,7 @@ def mock_dependencies() -> Generator[dict[str, Any], None, None]:
         parser_instance.next_unchecked_task.return_value = task
         parser_instance.find_task_by_id.return_value = task
         parser_instance.phase_complete.return_value = False
+        parser_instance.parse.return_value = PlanModel(tasks=[], phases=[])
 
         resolver_instance = MockResolver.return_value
         resolver_instance.resolve.return_value = (Mock(), Path("/mock/feature/dir"))


### PR DESCRIPTION
### Motivation

- Fix the restart/resume TDD workflow where pre-flight QC was erroneously treating regression tests that were intentionally failing as if they were unexpected failures. 
- Tasks marked with the `[expect-fail]` were treated no differently than real test failures and triggered out-of-sequence baseline-fix attempts.
- Support deterministic plan-linked expectations by requiring machine-resolvable test references so QC can ignore only explicitly expected failures while keeping the full toolchain running.

### Description

- Extend plan parsing (`scripts/dev_tools/atomic_executor/plan_parser.py`) to recognize a new `[expect-pass]` tag, preserve existing `[expect-fail]`, and extract a `test_ref` (either `pytest <nodeid>` form or `Add pytest `name` in `path`` prose) into `PlanTask` as `expect_pass: bool` and `test_ref: str | None`.
- Add a new helper module `scripts/dev_tools/atomic_executor/pytest_expectations.py` with `resolve_checked_test_expectations()` to produce normalized `ResolvedTestExpectations` and `parse_pytest_failure_output()` to extract failing nodeids and detect collection errors.
- Make preflight QC plan-aware by updating `cli.py` to: run `pytest` with `--color=no`, perform a `--collect-only` probe for checked expectation refs, parse pytest output, and treat failures matching checked `expected_fail_refs` as allowed while honoring `expected_pass_refs` overrides; fail fast on checked expectations lacking `test_ref`.
- Make phase-end QC plan-aware by extending `QCRunner.run_full(...)` (and adding `_run_pytest_with_expectations`) to accept `ResolvedTestExpectations` and apply the same filtering semantics at phase completion.
- Add fixtures and unit tests (parser, expectation resolution, pytest output parsing, preflight gating, and phase-end gating) and wire the CLI to resolve and forward expectations into preflight and phase-end checks.

### Testing

- Formatting: `poetry run black .` — passed.
- Linting: `poetry run ruff check` — passed.
- Type checking: `poetry run pyright` — passed.
- Test suite: `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing` — passed (all tests in suite completed; added tests exercised parser, expectation resolution, pytest parsing, preflight and phase-end gating).

Files changed (high level): `plan_parser.py`, `cli.py`, `qc_runner.py`, new `pytest_expectations.py`, plus new/updated tests and fixtures under `tests/scripts/dev_tools/atomic_executor/` and `tests/fixtures/atomic_executor/` to cover parsing and QC behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697153e7eb9483238f4dbf48c4ea9b43)